### PR TITLE
feat(drizzle): add count query functionality to resolver factory

### DIFF
--- a/packages/drizzle/CHANGELOG.md
+++ b/packages/drizzle/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## next (YYYY-MM-DD)
 
+- Feat: add count query functionality to resolver factory
 - Feat: Add column visibility configuration for input and filter generation
 
 ## 0.8.2 (2025-04-08)

--- a/packages/drizzle/src/factory/input.ts
+++ b/packages/drizzle/src/factory/input.ts
@@ -67,6 +67,21 @@ export class DrizzleInputFactory<TTable extends Table> {
     )
   }
 
+  public countArgs() {
+    const name = `${pascalCase(getTableName(this.table))}CountArgs`
+    const existing = weaverContext.getNamedType(name) as GraphQLObjectType
+    if (existing != null) return existing
+
+    return weaverContext.memoNamedType(
+      new GraphQLObjectType<CountArgs<TTable>>({
+        name,
+        fields: {
+          where: { type: this.filters() },
+        },
+      })
+    )
+  }
+
   public insertArrayArgs() {
     const name = `${pascalCase(getTableName(this.table))}InsertArrayArgs`
     const existing = weaverContext.getNamedType(name) as GraphQLObjectType
@@ -320,6 +335,10 @@ export interface SelectArrayArgs<TTable extends Table> {
 export interface SelectSingleArgs<TTable extends Table> {
   offset?: number
   orderBy?: Partial<Record<keyof InferSelectModel<TTable>, "asc" | "desc">>[]
+  where?: Filters<TTable>
+}
+
+export interface CountArgs<TTable extends Table> {
   where?: Filters<TTable>
 }
 

--- a/packages/drizzle/src/factory/types.ts
+++ b/packages/drizzle/src/factory/types.ts
@@ -13,6 +13,7 @@ import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 import type { RelationalQueryBuilder as SQLiteRelationalQueryBuilder } from "drizzle-orm/sqlite-core/query-builders/query"
 
 import type {
+  CountArgs,
   DeleteArgs,
   InsertArrayArgs,
   InsertSingleArgs,
@@ -99,6 +100,15 @@ export type InferSelectArrayOptions<
   TDatabase extends BaseDatabase,
   TTable extends Table,
 > = Parameters<QueryBuilder<TDatabase, TTable["_"]["name"]>["findMany"]>[0]
+
+export interface CountQuery<
+  TTable extends Table,
+  TInputI = SelectArrayArgs<TTable>,
+> extends QueryFactoryWithResolve<
+    CountArgs<TTable>,
+    GraphQLSilk<number, number>,
+    GraphQLSilk<CountArgs<TTable>, TInputI>
+  > {}
 
 export interface SelectSingleQuery<
   TDatabase extends BaseDatabase,

--- a/packages/drizzle/test/resolver-mysql.spec.gql
+++ b/packages/drizzle/test/resolver-mysql.spec.gql
@@ -170,7 +170,9 @@ enum OrderDirection {
 
 type Query {
   post(limit: Int, offset: Int, orderBy: [DrizzlePostOrderBy!], where: DrizzlePostFilters): [DrizzlePostItem!]!
+  postCount(where: DrizzlePostFilters): Int!
   postSingle(offset: Int, orderBy: [DrizzlePostOrderBy!], where: DrizzlePostFilters): DrizzlePostItem
   user(limit: Int, offset: Int, orderBy: [DrizzleUserOrderBy!], where: DrizzleUserFilters): [DrizzleUserItem!]!
+  userCount(where: DrizzleUserFilters): Int!
   userSingle(offset: Int, orderBy: [DrizzleUserOrderBy!], where: DrizzleUserFilters): DrizzleUserItem
 }

--- a/packages/drizzle/test/resolver-postgres.spec.gql
+++ b/packages/drizzle/test/resolver-postgres.spec.gql
@@ -193,7 +193,9 @@ input PgTextFiltersOr {
 
 type Query {
   post(limit: Int, offset: Int, orderBy: [DrizzlePostOrderBy!], where: DrizzlePostFilters): [DrizzlePostItem!]!
+  postCount(where: DrizzlePostFilters): Int!
   postSingle(offset: Int, orderBy: [DrizzlePostOrderBy!], where: DrizzlePostFilters): DrizzlePostItem
   user(limit: Int, offset: Int, orderBy: [DrizzleUserOrderBy!], where: DrizzleUserFilters): [DrizzleUserItem!]!
+  userCount(where: DrizzleUserFilters): Int!
   userSingle(offset: Int, orderBy: [DrizzleUserOrderBy!], where: DrizzleUserFilters): DrizzleUserItem
 }

--- a/packages/drizzle/test/resolver-sqlite.spec.gql
+++ b/packages/drizzle/test/resolver-sqlite.spec.gql
@@ -60,8 +60,10 @@ input PostUpdateInput {
 
 type Query {
   post(limit: Int, offset: Int, orderBy: [PostOrderBy!], where: PostFilters): [PostItem!]!
+  postCount(where: PostFilters): Int!
   postSingle(offset: Int, orderBy: [PostOrderBy!], where: PostFilters): PostItem
   user(limit: Int, offset: Int, orderBy: [UserOrderBy!], where: UserFilters): [UserItem!]!
+  userCount(where: UserFilters): Int!
   userSingle(offset: Int, orderBy: [UserOrderBy!], where: UserFilters): UserItem
 }
 


### PR DESCRIPTION
- Introduced `countArgs` method in `DrizzleInputFactory` to define input arguments for count queries.
- Implemented `countQuery` method in `DrizzleResolverFactory` to facilitate counting records with optional filters.
- Updated GraphQL schema to include `postCount` and `userCount` queries for counting posts and users.
- Enhanced tests to validate the behavior of the new count query functionality with various input scenarios.