### PR TITLE
fix(drizzle): update resolver factory options type

### DIFF
--- a/packages/drizzle/CHANGELOG.md
+++ b/packages/drizzle/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## next (YYYY-MM-DD)
 
+## 0.8.4 (2025-04-21)
+
+- Fix: update resolver factory options type
+
 ## 0.8.3 (2025-04-16)
 
 - Feat: add count query functionality to resolver factory

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gqloom/drizzle",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "GQLoom integration with Drizzle ORM",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/drizzle/src/factory/index.ts
+++ b/packages/drizzle/src/factory/index.ts
@@ -2,7 +2,7 @@ import type { Table } from "drizzle-orm"
 import { MySqlDatabase, type MySqlTable } from "drizzle-orm/mysql-core"
 import { PgDatabase, type PgTable } from "drizzle-orm/pg-core"
 import type { BaseSQLiteDatabase, SQLiteTable } from "drizzle-orm/sqlite-core"
-import type { DrizzleFactoryInputVisibilityBehaviors } from "../types"
+import type { DrizzleResolverFactoryOptions } from "../types"
 import { DrizzleMySQLResolverFactory } from "./resolver-mysql"
 import { DrizzlePostgresResolverFactory } from "./resolver-postgres"
 import { DrizzleSQLiteResolverFactory } from "./resolver-sqlite"
@@ -14,7 +14,7 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   tableName: TTableName,
-  options?: DrizzleFactoryInputVisibilityBehaviors<
+  options?: DrizzleResolverFactoryOptions<
     NonNullable<TDatabase["_"]["fullSchema"]>[TTableName]
   >
 ): DrizzleSQLiteResolverFactory<
@@ -27,7 +27,7 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   table: TTable,
-  options?: DrizzleFactoryInputVisibilityBehaviors<TTable>
+  options?: DrizzleResolverFactoryOptions<TTable>
 ): DrizzleSQLiteResolverFactory<TDatabase, TTable>
 
 export function drizzleResolverFactory<
@@ -36,7 +36,7 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   tableName: TTableName,
-  options?: DrizzleFactoryInputVisibilityBehaviors<
+  options?: DrizzleResolverFactoryOptions<
     NonNullable<TDatabase["_"]["fullSchema"]>[TTableName]
   >
 ): DrizzlePostgresResolverFactory<
@@ -49,7 +49,7 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   table: TTable,
-  options?: DrizzleFactoryInputVisibilityBehaviors<TTable>
+  options?: DrizzleResolverFactoryOptions<TTable>
 ): DrizzlePostgresResolverFactory<TDatabase, TTable>
 
 export function drizzleResolverFactory<
@@ -58,7 +58,7 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   tableName: TTableName,
-  options?: DrizzleFactoryInputVisibilityBehaviors<
+  options?: DrizzleResolverFactoryOptions<
     NonNullable<TDatabase["_"]["fullSchema"]>[TTableName]
   >
 ): DrizzleMySQLResolverFactory<
@@ -71,24 +71,25 @@ export function drizzleResolverFactory<
 >(
   db: TDatabase,
   table: TTable,
-  options?: DrizzleFactoryInputVisibilityBehaviors<TTable>
+  options?: DrizzleResolverFactoryOptions<TTable>
 ): DrizzleMySQLResolverFactory<TDatabase, TTable>
 
 export function drizzleResolverFactory(
   db: BaseDatabase,
-  tableOrName: Table | string
+  tableOrName: Table | string,
+  options?: DrizzleResolverFactoryOptions<Table>
 ) {
   const table =
     typeof tableOrName === "string"
       ? (db._.fullSchema[tableOrName] as Table)
       : tableOrName
   if (db instanceof PgDatabase) {
-    return new DrizzlePostgresResolverFactory(db, table as PgTable)
+    return new DrizzlePostgresResolverFactory(db, table as PgTable, options)
   }
   if (db instanceof MySqlDatabase) {
-    return new DrizzleMySQLResolverFactory(db, table as MySqlTable)
+    return new DrizzleMySQLResolverFactory(db, table as MySqlTable, options)
   }
-  return new DrizzleSQLiteResolverFactory(db, table as SQLiteTable)
+  return new DrizzleSQLiteResolverFactory(db, table as SQLiteTable, options)
 }
 
 export * from "./input"


### PR DESCRIPTION
- Replaced `DrizzleFactoryInputVisibilityBehaviors` with `DrizzleResolverFactoryOptions` in the `drizzleResolverFactory` function signatures.
- Updated the implementation of resolver factories for MySQL, PostgreSQL, and SQLite to accept the new options type.
- Ensured consistency in the handling of options across different database resolver factories.