### PR TITLE
feat(drizzle): enhance insert operations with onConflict handling

### DIFF
--- a/packages/drizzle/CHANGELOG.md
+++ b/packages/drizzle/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## next (YYYY-MM-DD)
 
+- Feat: add `onConflictDoUpdate` and `onConflictDoNothing` to insert mutation for Postgres and SQLite
+
 ## 0.8.4 (2025-04-21)
 
 - Fix: update resolver factory options type

--- a/packages/drizzle/src/factory/resolver-postgres.ts
+++ b/packages/drizzle/src/factory/resolver-postgres.ts
@@ -12,8 +12,8 @@ import type { PgDatabase, PgTable } from "drizzle-orm/pg-core"
 import type { GraphQLOutputType } from "graphql"
 import type {
   DeleteArgs,
-  InsertArrayArgs,
-  InsertSingleArgs,
+  InsertArrayWithOnConflictArgs,
+  InsertSingleWithOnConflictArgs,
   UpdateArgs,
 } from "./input"
 import { DrizzleResolverFactory } from "./resolver"
@@ -29,55 +29,88 @@ export class DrizzlePostgresResolverFactory<
   TDatabase extends PgDatabase<any, any, any>,
   TTable extends PgTable,
 > extends DrizzleResolverFactory<TDatabase, TTable> {
-  public insertArrayMutation<TInputI = InsertArrayArgs<TTable>>({
+  public insertArrayMutation<TInputI = InsertArrayWithOnConflictArgs<TTable>>({
     input,
     ...options
   }: GraphQLFieldOptions & {
-    input?: GraphQLSilk<InsertArrayArgs<TTable>, TInputI>
+    input?: GraphQLSilk<InsertArrayWithOnConflictArgs<TTable>, TInputI>
     middlewares?: Middleware<
       InsertArrayMutationReturningItems<TTable, TInputI>
     >[]
   } = {}): InsertArrayMutationReturningItems<TTable, TInputI> {
     input ??= silk(
-      () => this.inputFactory.insertArrayArgs() as GraphQLOutputType
+      () =>
+        this.inputFactory.insertArrayWithOnConflictArgs() as GraphQLOutputType
     )
 
     return new MutationFactoryWithResolve(this.output.$list(), {
       ...options,
       input,
-      resolve: async (args) => {
-        const result = await this.db
-          .insert(this.table)
-          .values(args.values)
-          .returning()
-
-        return result
+      resolve: async (args: InsertArrayWithOnConflictArgs<TTable>) => {
+        let query: any = this.db.insert(this.table).values(args.values)
+        if (args.onConflictDoUpdate) {
+          query = query.onConflictDoUpdate({
+            target: args.onConflictDoUpdate.target.map((t) => this.toColumn(t)),
+            set: args.onConflictDoUpdate.set,
+            targetWhere: this.extractFilters(
+              args.onConflictDoUpdate.targetWhere
+            ),
+            setWhere: this.extractFilters(args.onConflictDoUpdate.setWhere),
+          })
+        }
+        if (args.onConflictDoNothing) {
+          query = query.onConflictDoNothing({
+            target: args.onConflictDoNothing.target?.map((t) =>
+              this.toColumn(t)
+            ),
+            where: this.extractFilters(args.onConflictDoNothing.where),
+          })
+        }
+        return await query.returning()
       },
     } as MutationOptions<any, any>)
   }
 
-  public insertSingleMutation<TInputI = InsertSingleArgs<TTable>>({
+  public insertSingleMutation<
+    TInputI = InsertSingleWithOnConflictArgs<TTable>,
+  >({
     input,
     ...options
   }: GraphQLFieldOptions & {
-    input?: GraphQLSilk<InsertSingleArgs<TTable>, TInputI>
+    input?: GraphQLSilk<InsertSingleWithOnConflictArgs<TTable>, TInputI>
     middlewares?: Middleware<
       InsertSingleMutationReturningItem<TTable, TInputI>
     >[]
   } = {}): InsertSingleMutationReturningItem<TTable, TInputI> {
     input ??= silk(
-      () => this.inputFactory.insertSingleArgs() as GraphQLOutputType
+      () =>
+        this.inputFactory.insertSingleWithOnConflictArgs() as GraphQLOutputType
     )
 
     return new MutationFactoryWithResolve(this.output.$nullable(), {
       ...options,
       input,
-      resolve: async (args) => {
-        const result = await this.db
-          .insert(this.table)
-          .values(args.value)
-          .returning()
-
+      resolve: async (args: InsertSingleWithOnConflictArgs<TTable>) => {
+        let query: any = this.db.insert(this.table).values(args.value)
+        if (args.onConflictDoUpdate) {
+          query = query.onConflictDoUpdate({
+            target: args.onConflictDoUpdate.target.map((t) => this.toColumn(t)),
+            set: args.onConflictDoUpdate.set,
+            targetWhere: this.extractFilters(
+              args.onConflictDoUpdate.targetWhere
+            ),
+            setWhere: this.extractFilters(args.onConflictDoUpdate.setWhere),
+          })
+        }
+        if (args.onConflictDoNothing) {
+          query = query.onConflictDoNothing({
+            target: args.onConflictDoNothing.target?.map((t) =>
+              this.toColumn(t)
+            ),
+            where: this.extractFilters(args.onConflictDoNothing.where),
+          })
+        }
+        const result = await query.returning()
         return result[0] as any
       },
     } as MutationOptions<any, any>)

--- a/packages/drizzle/src/factory/resolver-sqlite.ts
+++ b/packages/drizzle/src/factory/resolver-sqlite.ts
@@ -12,8 +12,8 @@ import type { BaseSQLiteDatabase, SQLiteTable } from "drizzle-orm/sqlite-core"
 import type { GraphQLOutputType } from "graphql"
 import type {
   DeleteArgs,
-  InsertArrayArgs,
-  InsertSingleArgs,
+  InsertArrayWithOnConflictArgs,
+  InsertSingleWithOnConflictArgs,
   UpdateArgs,
 } from "./input"
 import { DrizzleResolverFactory } from "./resolver"
@@ -29,54 +29,87 @@ export class DrizzleSQLiteResolverFactory<
   TDatabase extends BaseSQLiteDatabase<any, any, any, any>,
   TTable extends SQLiteTable,
 > extends DrizzleResolverFactory<TDatabase, TTable> {
-  public insertArrayMutation<TInputI = InsertArrayArgs<TTable>>({
+  public insertArrayMutation<TInputI = InsertArrayWithOnConflictArgs<TTable>>({
     input,
     ...options
   }: GraphQLFieldOptions & {
-    input?: GraphQLSilk<InsertArrayArgs<TTable>, TInputI>
+    input?: GraphQLSilk<InsertArrayWithOnConflictArgs<TTable>, TInputI>
     middlewares?: Middleware<
       InsertArrayMutationReturningItems<TTable, TInputI>
     >[]
   } = {}): InsertArrayMutationReturningItems<TTable, TInputI> {
     input ??= silk(
-      () => this.inputFactory.insertArrayArgs() as GraphQLOutputType
+      () =>
+        this.inputFactory.insertArrayWithOnConflictArgs() as GraphQLOutputType
     )
 
     return new MutationFactoryWithResolve(this.output.$list(), {
       ...options,
       input,
-      resolve: async (args) => {
-        const result = await this.db
-          .insert(this.table)
-          .values(args.values)
-          .returning()
-        return result
+      resolve: async (args: InsertArrayWithOnConflictArgs<TTable>) => {
+        let query: any = this.db.insert(this.table).values(args.values)
+        if (args.onConflictDoUpdate) {
+          query = query.onConflictDoUpdate({
+            target: args.onConflictDoUpdate.target.map((t) => this.toColumn(t)),
+            set: args.onConflictDoUpdate.set,
+            targetWhere: this.extractFilters(
+              args.onConflictDoUpdate.targetWhere
+            ),
+            setWhere: this.extractFilters(args.onConflictDoUpdate.setWhere),
+          })
+        }
+        if (args.onConflictDoNothing) {
+          query = query.onConflictDoNothing({
+            target: args.onConflictDoNothing.target?.map((t) =>
+              this.toColumn(t)
+            ),
+            where: this.extractFilters(args.onConflictDoNothing.where),
+          })
+        }
+        return await query.returning()
       },
     } as MutationOptions<any, any>)
   }
 
-  public insertSingleMutation<TInputI = InsertSingleArgs<TTable>>({
+  public insertSingleMutation<
+    TInputI = InsertSingleWithOnConflictArgs<TTable>,
+  >({
     input,
     ...options
   }: GraphQLFieldOptions & {
-    input?: GraphQLSilk<InsertSingleArgs<TTable>, TInputI>
+    input?: GraphQLSilk<InsertSingleWithOnConflictArgs<TTable>, TInputI>
     middlewares?: Middleware<
       InsertSingleMutationReturningItem<TTable, TInputI>
     >[]
   } = {}): InsertSingleMutationReturningItem<TTable, TInputI> {
     input ??= silk(
-      () => this.inputFactory.insertSingleArgs() as GraphQLOutputType
+      () =>
+        this.inputFactory.insertSingleWithOnConflictArgs() as GraphQLOutputType
     )
     return new MutationFactoryWithResolve(this.output.$nullable(), {
       ...options,
       input,
-      resolve: async (args) => {
-        const result = await this.db
-          .insert(this.table)
-          .values(args.value)
-          .returning()
-
-        return result[0] as any
+      resolve: async (args: InsertSingleWithOnConflictArgs<TTable>) => {
+        let query: any = this.db.insert(this.table).values(args.value)
+        if (args.onConflictDoUpdate) {
+          query = query.onConflictDoUpdate({
+            target: args.onConflictDoUpdate.target.map((t) => this.toColumn(t)),
+            set: args.onConflictDoUpdate.set,
+            targetWhere: this.extractFilters(
+              args.onConflictDoUpdate.targetWhere
+            ),
+            setWhere: this.extractFilters(args.onConflictDoUpdate.setWhere),
+          })
+        }
+        if (args.onConflictDoNothing) {
+          query = query.onConflictDoNothing({
+            target: args.onConflictDoNothing.target?.map((t) =>
+              this.toColumn(t)
+            ),
+            where: this.extractFilters(args.onConflictDoNothing.where),
+          })
+        }
+        return (await query.returning())[0] as any
       },
     } as MutationOptions<any, any>)
   }

--- a/packages/drizzle/src/factory/resolver.ts
+++ b/packages/drizzle/src/factory/resolver.ts
@@ -316,6 +316,16 @@ export abstract class DrizzleResolverFactory<
     return and(...variants)
   }
 
+  protected toColumn(columnName: string) {
+    const column = getTableColumns(this.table)[columnName]
+    if (!column) {
+      throw new Error(
+        `Column ${columnName} not found in table ${this.tableName}`
+      )
+    }
+    return column
+  }
+
   public relationField<
     TRelationName extends keyof InferTableRelationalConfig<
       QueryBuilder<TDatabase, InferTableName<TTable>>

--- a/packages/drizzle/src/factory/types.ts
+++ b/packages/drizzle/src/factory/types.ts
@@ -16,7 +16,9 @@ import type {
   CountArgs,
   DeleteArgs,
   InsertArrayArgs,
+  InsertArrayWithOnConflictArgs,
   InsertSingleArgs,
+  InsertSingleWithOnConflictArgs,
   MutationResult,
   SelectArrayArgs,
   SelectSingleArgs,
@@ -159,11 +161,11 @@ export type InsertArrayMutation<
 
 export interface InsertArrayMutationReturningItems<
   TTable extends Table,
-  TInputI = InsertArrayArgs<TTable>,
+  TInputI = InsertArrayWithOnConflictArgs<TTable>,
 > extends MutationFactoryWithResolve<
-    InsertArrayArgs<TTable>,
+    InsertArrayWithOnConflictArgs<TTable>,
     GraphQLSilk<InferSelectModel<TTable>[], InferSelectModel<TTable>[]>,
-    GraphQLSilk<InsertArrayArgs<TTable>, TInputI>
+    GraphQLSilk<InsertArrayWithOnConflictArgs<TTable>, TInputI>
   > {}
 
 export interface InsertArrayMutationReturningSuccess<
@@ -184,14 +186,14 @@ export type InsertSingleMutation<
 
 export interface InsertSingleMutationReturningItem<
   TTable extends Table,
-  TInputI = InsertSingleArgs<TTable>,
+  TInputI = InsertSingleWithOnConflictArgs<TTable>,
 > extends MutationFactoryWithResolve<
-    InsertSingleArgs<TTable>,
+    InsertSingleWithOnConflictArgs<TTable>,
     GraphQLSilk<
       InferSelectModel<TTable> | null | undefined,
       InferSelectModel<TTable> | null | undefined
     >,
-    GraphQLSilk<InsertSingleArgs<TTable>, TInputI>
+    GraphQLSilk<InsertSingleWithOnConflictArgs<TTable>, TInputI>
   > {}
 
 export interface InsertSingleMutationReturningSuccess<

--- a/packages/drizzle/test/input-factory.spec.ts
+++ b/packages/drizzle/test/input-factory.spec.ts
@@ -71,6 +71,43 @@ describe("DrizzleInputFactory", () => {
     `)
   })
 
+  it("should generate TableColumnEnum type for a table", () => {
+    expect(printType(inputFactory.tableColumnEnum())).toMatchInlineSnapshot(`
+      "enum UsersTableColumn {
+        id
+        name
+        email
+        password
+        createdAt
+        updatedAt
+      }"
+    `)
+  })
+
+  it("should generate InsertOnConflictDoUpdateInput type for a table", () => {
+    expect(
+      printType(inputFactory.insertOnConflictDoUpdateInput())
+    ).toMatchInlineSnapshot(`
+      "type UsersInsertOnConflictDoUpdateInput {
+        target: [UsersTableColumn!]!
+        set: UsersInsertInput
+        targetWhere: UsersFilters
+        setWhere: UsersFilters
+      }"
+    `)
+  })
+
+  it("should generate InsertOnConflictDoNothingInput type for a table", () => {
+    expect(
+      printType(inputFactory.insertOnConflictDoNothingInput())
+    ).toMatchInlineSnapshot(`
+      "type UsersInsertOnConflictDoNothingInput {
+        target: [UsersTableColumn!]
+        where: UsersFilters
+      }"
+    `)
+  })
+
   describe("with column visibility options", () => {
     const options: DrizzleFactoryInputVisibilityBehaviors<typeof userTable> = {
       "*": {

--- a/packages/drizzle/test/resolver-postgres.spec.gql
+++ b/packages/drizzle/test/resolver-postgres.spec.gql
@@ -20,6 +20,18 @@ input DrizzlePostInsertInput {
   title: String!
 }
 
+input DrizzlePostInsertOnConflictDoNothingInput {
+  target: [DrizzlePostTableColumn!]
+  where: DrizzlePostFilters
+}
+
+input DrizzlePostInsertOnConflictDoUpdateInput {
+  set: DrizzlePostInsertInput
+  setWhere: DrizzlePostFilters
+  target: [DrizzlePostTableColumn!]!
+  targetWhere: DrizzlePostFilters
+}
+
 type DrizzlePostItem {
   author: DrizzleUserItem
   authorId: Int
@@ -33,6 +45,13 @@ input DrizzlePostOrderBy {
   content: OrderDirection
   id: OrderDirection
   title: OrderDirection
+}
+
+enum DrizzlePostTableColumn {
+  authorId
+  content
+  id
+  title
 }
 
 input DrizzlePostUpdateInput {
@@ -64,6 +83,18 @@ input DrizzleUserInsertInput {
   name: String!
 }
 
+input DrizzleUserInsertOnConflictDoNothingInput {
+  target: [DrizzleUserTableColumn!]
+  where: DrizzleUserFilters
+}
+
+input DrizzleUserInsertOnConflictDoUpdateInput {
+  set: DrizzleUserInsertInput
+  setWhere: DrizzleUserFilters
+  target: [DrizzleUserTableColumn!]!
+  targetWhere: DrizzleUserFilters
+}
+
 type DrizzleUserItem {
   age: Int
   email: String
@@ -79,6 +110,13 @@ input DrizzleUserOrderBy {
   name: OrderDirection
 }
 
+enum DrizzleUserTableColumn {
+  age
+  email
+  id
+  name
+}
+
 input DrizzleUserUpdateInput {
   age: Int
   email: String
@@ -89,10 +127,10 @@ input DrizzleUserUpdateInput {
 type Mutation {
   deleteFromPost(where: DrizzlePostFilters): [DrizzlePostItem!]!
   deleteFromUser(where: DrizzleUserFilters): [DrizzleUserItem!]!
-  insertIntoPost(values: [DrizzlePostInsertInput!]!): [DrizzlePostItem!]!
-  insertIntoPostSingle(value: DrizzlePostInsertInput!): DrizzlePostItem
-  insertIntoUser(values: [DrizzleUserInsertInput!]!): [DrizzleUserItem!]!
-  insertIntoUserSingle(value: DrizzleUserInsertInput!): DrizzleUserItem
+  insertIntoPost(onConflictDoNothing: DrizzlePostInsertOnConflictDoNothingInput, onConflictDoUpdate: DrizzlePostInsertOnConflictDoUpdateInput, values: [DrizzlePostInsertInput!]!): [DrizzlePostItem!]!
+  insertIntoPostSingle(onConflictDoNothing: DrizzlePostInsertOnConflictDoNothingInput, onConflictDoUpdate: DrizzlePostInsertOnConflictDoUpdateInput, value: DrizzlePostInsertInput!): DrizzlePostItem
+  insertIntoUser(onConflictDoNothing: DrizzleUserInsertOnConflictDoNothingInput, onConflictDoUpdate: DrizzleUserInsertOnConflictDoUpdateInput, values: [DrizzleUserInsertInput!]!): [DrizzleUserItem!]!
+  insertIntoUserSingle(onConflictDoNothing: DrizzleUserInsertOnConflictDoNothingInput, onConflictDoUpdate: DrizzleUserInsertOnConflictDoUpdateInput, value: DrizzleUserInsertInput!): DrizzleUserItem
   updatePost(set: DrizzlePostUpdateInput!, where: DrizzlePostFilters): [DrizzlePostItem!]!
   updateUser(set: DrizzleUserUpdateInput!, where: DrizzleUserFilters): [DrizzleUserItem!]!
 }

--- a/packages/drizzle/test/resolver-postgres.spec.ts
+++ b/packages/drizzle/test/resolver-postgres.spec.ts
@@ -217,6 +217,104 @@ describe("resolver by postgres", () => {
       expect(Tina).toBeDefined()
     })
 
+    it("should insert a user with on conflict correctly", async () => {
+      const q = /* GraphQL */ `
+        mutation insertIntoUser($values: [DrizzleUserInsertInput!]!, $doNothing: DrizzleUserInsertOnConflictDoNothingInput, $doUpdate: DrizzleUserInsertOnConflictDoUpdateInput) {
+          insertIntoUser(onConflictDoNothing: $doNothing, onConflictDoUpdate: $doUpdate, values: $values) {
+            id
+            name
+          }
+        }
+      `
+
+      await expect(
+        execute(q, {
+          values: [{ name: "Tina", id: 77 }],
+        })
+      ).resolves.toMatchObject({
+        insertIntoUser: [{ name: "Tina" }],
+      })
+
+      await expect(
+        execute(q, {
+          values: [{ name: "Tina", id: 77 }],
+          doNothing: {},
+        })
+      ).resolves.toMatchObject({
+        insertIntoUser: [],
+      })
+
+      await expect(
+        execute(q, {
+          values: [{ name: "Tina", id: 77 }],
+          doNothing: { target: ["id"] },
+        })
+      ).resolves.toMatchObject({
+        insertIntoUser: [],
+      })
+
+      await expect(
+        execute(q, {
+          values: [{ name: "TinaInsert", id: 77 }],
+          doUpdate: {
+            target: ["id"],
+            set: { name: "TinaUpdate" },
+          },
+        })
+      ).resolves.toMatchObject({
+        insertIntoUser: [{ name: "TinaUpdate" }],
+      })
+    })
+
+    it("should insert a single user with on conflict correctly", async () => {
+      const q = /* GraphQL */ `
+        mutation insertIntoUserSingle($value: DrizzleUserInsertInput!, $doNothing: DrizzleUserInsertOnConflictDoNothingInput, $doUpdate: DrizzleUserInsertOnConflictDoUpdateInput) {
+          insertIntoUserSingle(onConflictDoNothing: $doNothing, onConflictDoUpdate: $doUpdate, value: $value) {
+            id
+            name
+          }
+        }
+      `
+
+      await expect(
+        execute(q, {
+          value: { name: "Tina", id: 78 },
+        })
+      ).resolves.toMatchObject({
+        insertIntoUserSingle: { name: "Tina" },
+      })
+
+      await expect(
+        execute(q, {
+          value: { name: "Tina", id: 78 },
+          doNothing: {},
+        })
+      ).resolves.toMatchObject({
+        insertIntoUserSingle: null,
+      })
+
+      await expect(
+        execute(q, {
+          value: { name: "Tina", id: 78 },
+          doNothing: { target: ["id"] },
+        })
+      ).resolves.toMatchObject({
+        insertIntoUserSingle: null,
+      })
+
+      await expect(
+        execute(q, {
+          value: { name: "Tina", id: 78 },
+          doUpdate: {
+            target: ["id"],
+            set: { name: "TinaUpdate" },
+          },
+        })
+      ).resolves.toMatchObject({
+        insertIntoUserSingle: { name: "TinaUpdate" },
+      })
+    })
+
     it("should update user information correctly", async () => {
       const q = /* GraphQL */ `
         mutation updateUser($set: DrizzleUserUpdateInput!, $where: DrizzleUserFilters!) {

--- a/packages/drizzle/test/resolver-sqlite.spec.gql
+++ b/packages/drizzle/test/resolver-sqlite.spec.gql
@@ -1,10 +1,10 @@
 type Mutation {
   deleteFromPost(where: PostFilters): [PostItem!]!
   deleteFromUser(where: UserFilters): [UserItem!]!
-  insertIntoPost(values: [PostInsertInput!]!): [PostItem!]!
-  insertIntoPostSingle(value: PostInsertInput!): PostItem
-  insertIntoUser(values: [UserInsertInput!]!): [UserItem!]!
-  insertIntoUserSingle(value: UserInsertInput!): UserItem
+  insertIntoPost(onConflictDoNothing: PostInsertOnConflictDoNothingInput, onConflictDoUpdate: PostInsertOnConflictDoUpdateInput, values: [PostInsertInput!]!): [PostItem!]!
+  insertIntoPostSingle(onConflictDoNothing: PostInsertOnConflictDoNothingInput, onConflictDoUpdate: PostInsertOnConflictDoUpdateInput, value: PostInsertInput!): PostItem
+  insertIntoUser(onConflictDoNothing: UserInsertOnConflictDoNothingInput, onConflictDoUpdate: UserInsertOnConflictDoUpdateInput, values: [UserInsertInput!]!): [UserItem!]!
+  insertIntoUserSingle(onConflictDoNothing: UserInsertOnConflictDoNothingInput, onConflictDoUpdate: UserInsertOnConflictDoUpdateInput, value: UserInsertInput!): UserItem
   updatePost(set: PostUpdateInput!, where: PostFilters): [PostItem!]!
   updateUser(set: UserUpdateInput!, where: UserFilters): [UserItem!]!
 }
@@ -36,6 +36,18 @@ input PostInsertInput {
   title: String!
 }
 
+input PostInsertOnConflictDoNothingInput {
+  target: [PostTableColumn!]
+  where: PostFilters
+}
+
+input PostInsertOnConflictDoUpdateInput {
+  set: PostInsertInput
+  setWhere: PostFilters
+  target: [PostTableColumn!]!
+  targetWhere: PostFilters
+}
+
 type PostItem {
   author: UserItem
   authorId: Int
@@ -49,6 +61,13 @@ input PostOrderBy {
   content: OrderDirection
   id: OrderDirection
   title: OrderDirection
+}
+
+enum PostTableColumn {
+  authorId
+  content
+  id
+  title
 }
 
 input PostUpdateInput {
@@ -157,6 +176,18 @@ input UserInsertInput {
   name: String!
 }
 
+input UserInsertOnConflictDoNothingInput {
+  target: [UserTableColumn!]
+  where: UserFilters
+}
+
+input UserInsertOnConflictDoUpdateInput {
+  set: UserInsertInput
+  setWhere: UserFilters
+  target: [UserTableColumn!]!
+  targetWhere: UserFilters
+}
+
 type UserItem {
   age: Int
   courses: [StudentToCourseItem!]!
@@ -171,6 +202,13 @@ input UserOrderBy {
   email: OrderDirection
   id: OrderDirection
   name: OrderDirection
+}
+
+enum UserTableColumn {
+  age
+  email
+  id
+  name
 }
 
 input UserUpdateInput {


### PR DESCRIPTION
- Added support for `onConflictDoUpdate` and `onConflictDoNothing` in `insertArrayMutation` and `insertSingleMutation` methods for both PostgreSQL and SQLite resolver factories.
- Introduced new input types `InsertArrayWithOnConflictArgs` and `InsertSingleWithOnConflictArgs` to accommodate conflict resolution strategies.
- Updated GraphQL schema to reflect the new input types and their usage in mutation operations.
- Enhanced tests to validate the new conflict handling functionality for user insertions.