### PR TITLE
refactor(resolver): update input type handling to use 'void' instead …

### DIFF
--- a/packages/core/src/resolver/input.ts
+++ b/packages/core/src/resolver/input.ts
@@ -5,19 +5,19 @@ import { isSilk } from "./silk"
 import type { GraphQLSilk } from "./types"
 
 export type InferInputI<
-  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | undefined,
-> = TInput extends undefined
-  ? undefined
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void,
+> = TInput extends void
+  ? void
   : TInput extends GraphQLSilk
     ? StandardSchemaV1.InferInput<TInput>
     : TInput extends Record<string, GraphQLSilk>
       ? {
           [K in keyof TInput]: StandardSchemaV1.InferInput<TInput[K]>
         }
-      : undefined
+      : void
 
 export type InferInputO<
-  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void,
 > = TInput extends undefined
   ? undefined
   : TInput extends GraphQLSilk
@@ -29,7 +29,7 @@ export type InferInputO<
       : never
 
 export interface CallableInputParser<
-  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | void,
 > {
   /**
    * input schema
@@ -58,7 +58,7 @@ export interface CallableInputParser<
 }
 
 export function createInputParser<
-  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | void,
 >(schema: TSchema, value: InferInputI<TSchema>): CallableInputParser<TSchema> {
   let result: StandardSchemaV1.Result<InferInputO<TSchema>> | undefined
 
@@ -81,7 +81,7 @@ export function createInputParser<
 }
 
 export function parseInputValue<
-  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+  TSchema extends GraphQLSilk | Record<string, GraphQLSilk> | void,
 >(
   inputSchema: TSchema,
   input: any

--- a/packages/core/src/resolver/resolver-chain-factory.ts
+++ b/packages/core/src/resolver/resolver-chain-factory.ts
@@ -34,10 +34,7 @@ import type {
 
 export interface IChainFactory<
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
 > {
   description(description: GraphQLFieldOptions["description"]): this
 
@@ -216,10 +213,7 @@ export class FieldChainFactory<
 
 export class QueryChainFactory<
     TOutput extends GraphQLSilk = never,
-    TInput extends
-      | GraphQLSilk
-      | Record<string, GraphQLSilk>
-      | undefined = undefined,
+    TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
   >
   extends BaseChainFactory<Loom.Query<TOutput, TInput>>
   implements IChainFactory<TOutput, TInput>
@@ -231,7 +225,7 @@ export class QueryChainFactory<
       input: QueryChainFactory.prototype.input,
       resolve: QueryChainFactory.prototype.resolve,
       clone: QueryChainFactory.prototype.clone,
-    } as any as QueryChainFactory<never, undefined>
+    } as any as QueryChainFactory<never, void>
   }
 
   protected clone(options?: Partial<ChainFactoryOptions>): this {

--- a/packages/core/src/resolver/resolver.spec.ts
+++ b/packages/core/src/resolver/resolver.spec.ts
@@ -395,7 +395,7 @@ describe("executor", () => {
     const saved = await executor.saveGiraffe({ name: "Skyler" })
     expect(saved).toEqual({
       name: "Skyler",
-      birthday: new Date(),
+      birthday: expect.any(Date),
       heightInMeters: 5,
     })
     expect(giraffeMap.get("Skyler")).toEqual(saved)

--- a/packages/core/src/resolver/resolver.spec.ts
+++ b/packages/core/src/resolver/resolver.spec.ts
@@ -7,9 +7,10 @@ import {
   lexicographicSortSchema,
   printSchema,
 } from "graphql"
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { weave } from "../schema"
 import type { Middleware } from "../utils"
+import { createMemoization } from "../utils/context"
 import { field, mutation, query, resolver } from "./resolver"
 import { silk } from "./silk"
 
@@ -335,5 +336,91 @@ describe("resolver", () => {
 
     const g = schema.getType("Giraffe") as GraphQLObjectType<IGiraffe>
     expect(g.extensions).toEqual({ foo: "bar" })
+  })
+})
+
+describe("executor", () => {
+  /** name -> giraffe */
+  const giraffeMap = new Map<string, IGiraffe>()
+
+  const useDefaultName = createMemoization(() => "Giraffe")
+
+  const giraffeResolver = resolver.of(Giraffe, {
+    age: field(silk(GraphQLInt), async (giraffe) => {
+      return new Date().getFullYear() - giraffe.birthday.getFullYear()
+    }),
+
+    giraffe: query(silk.nullable(Giraffe))
+      .input({ name: silk(new GraphQLNonNull(GraphQLString)) })
+      .resolve(({ name }) => {
+        return giraffeMap.get(name)
+      }),
+    allGiraffes: query(silk.list(Giraffe)).resolve(() =>
+      Array.from(giraffeMap.values())
+    ),
+
+    saveGiraffe: mutation(Giraffe)
+      .input(GiraffeInput)
+      .resolve((data) => {
+        const giraffe = {
+          name: data.name ?? useDefaultName(),
+          birthday: new Date(data.birthday ?? new Date()),
+          heightInMeters: data.heightInMeters ?? 5,
+        }
+        giraffeMap.set(giraffe.name, giraffe)
+        return giraffe
+      }),
+  })
+
+  let logs: string[] = []
+  giraffeResolver.use(async (next) => {
+    logs.push("before")
+    const result = await next()
+    logs.push("after")
+    return result
+  })
+
+  beforeEach(() => {
+    giraffeMap.clear()
+    logs = []
+  })
+  afterEach(() => {
+    giraffeMap.clear()
+    logs = []
+  })
+
+  it("should work", async () => {
+    const executor = giraffeResolver.toExecutor()
+
+    const saved = await executor.saveGiraffe({ name: "Skyler" })
+    expect(saved).toEqual({
+      name: "Skyler",
+      birthday: new Date(),
+      heightInMeters: 5,
+    })
+    expect(giraffeMap.get("Skyler")).toEqual(saved)
+
+    const giraffes = await executor.allGiraffes()
+    expect(giraffes).toEqual([saved])
+  })
+
+  it("should work with middlewares", async () => {
+    const executor = giraffeResolver.toExecutor()
+    await executor.saveGiraffe({ name: "Skyler" })
+    expect(logs).toEqual(["before", "after"])
+  })
+
+  it("should work with memoization", async () => {
+    const memoization = new WeakMap()
+    memoization.set(useDefaultName.key, "Skyler")
+
+    const executor = giraffeResolver.toExecutor({ memoization })
+    const saved = await executor.saveGiraffe({})
+
+    expect(saved).toEqual({
+      name: "Skyler",
+      birthday: new Date(),
+      heightInMeters: 5,
+    })
   })
 })

--- a/packages/core/src/resolver/types-loom.ts
+++ b/packages/core/src/resolver/types-loom.ts
@@ -12,7 +12,7 @@ import type {
 export interface FieldMeta extends GraphQLFieldOptions {
   operation: "field" | "query" | "mutation" | "subscription"
   output: GraphQLSilk
-  input: GraphQLSilk | Record<string, GraphQLSilk> | undefined
+  input: GraphQLSilk | Record<string, GraphQLSilk> | void
   dependencies?: string[]
   resolve: (...args: any) => MayPromise<any>
 }
@@ -24,10 +24,7 @@ export interface BaseField {
 export interface Field<
   TParent extends GraphQLSilk,
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
   TDependencies extends string[] | undefined = undefined,
 > extends BaseField {
   "~meta": {
@@ -48,10 +45,7 @@ export interface Field<
 
 export interface Query<
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
 > extends BaseField {
   "~meta": {
     operation: "query"
@@ -67,10 +61,7 @@ export interface Query<
 
 export interface Mutation<
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
 > extends BaseField {
   "~meta": {
     operation: "mutation"
@@ -86,10 +77,7 @@ export interface Mutation<
 
 export interface Subscription<
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
   TValue = StandardSchemaV1.InferOutput<TOutput>,
 > extends BaseField {
   "~meta": {
@@ -124,11 +112,11 @@ export interface Resolver {
 }
 
 export type Operation =
-  | Query<GraphQLSilk, GraphQLSilk | Record<string, GraphQLSilk> | undefined>
-  | Mutation<GraphQLSilk, GraphQLSilk | Record<string, GraphQLSilk> | undefined>
+  | Query<GraphQLSilk, GraphQLSilk | Record<string, GraphQLSilk> | void>
+  | Mutation<GraphQLSilk, GraphQLSilk | Record<string, GraphQLSilk> | void>
   | Subscription<
       GraphQLSilk,
-      GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+      GraphQLSilk | Record<string, GraphQLSilk> | void,
       any
     >
 
@@ -136,7 +124,7 @@ export type FieldOrOperation =
   | Field<
       GraphQLSilk,
       GraphQLSilk,
-      GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+      GraphQLSilk | Record<string, GraphQLSilk> | void,
       string[] | undefined
     >
   | Operation

--- a/packages/core/src/resolver/types.ts
+++ b/packages/core/src/resolver/types.ts
@@ -72,10 +72,7 @@ export type InferFieldOutput<TField extends Loom.BaseField> =
  */
 export interface QueryOptions<
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
 > extends ResolverOptions<Loom.Query<TOutput, TInput>>,
     GraphQLFieldOptions {
   input?: TInput
@@ -108,14 +105,11 @@ export interface QueryFactory {
   <TOutput extends GraphQLSilk>(
     output: TOutput,
     resolve: () => MayPromise<StandardSchemaV1.InferOutput<TOutput>>
-  ): Loom.Query<TOutput, undefined>
+  ): Loom.Query<TOutput, void>
 
   <
     TOutput extends GraphQLSilk,
-    TInput extends
-      | GraphQLSilk
-      | Record<string, GraphQLSilk>
-      | undefined = undefined,
+    TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
   >(
     output: TOutput,
     options: QueryOptions<TOutput, TInput>
@@ -123,12 +117,12 @@ export interface QueryFactory {
 
   <TOutput extends GraphQLSilk>(
     output: TOutput
-  ): QueryChainFactory<TOutput, undefined>
+  ): QueryChainFactory<TOutput, void>
 }
 
 export interface QueryFactoryWithChain
   extends QueryFactory,
-    QueryChainFactory<never, undefined> {}
+    QueryChainFactory<never, void> {}
 
 /**
  * Function to create a GraphQL mutation.
@@ -168,10 +162,7 @@ export interface MutationFactoryWithChain
 export interface FieldOptions<
   TParent extends GraphQLSilk,
   TOutput extends GraphQLSilk,
-  TInput extends
-    | GraphQLSilk
-    | Record<string, GraphQLSilk>
-    | undefined = undefined,
+  TInput extends GraphQLSilk | Record<string, GraphQLSilk> | void = void,
   TDependencies extends string[] | undefined = undefined,
 > extends ResolverOptions<Loom.Field<TParent, TOutput, TInput, TDependencies>>,
     GraphQLFieldOptions {

--- a/packages/core/src/schema/input.ts
+++ b/packages/core/src/schema/input.ts
@@ -27,7 +27,7 @@ interface EnsureInputOptions {
 }
 
 export function inputToArgs(
-  input: GraphQLSilk | Record<string, GraphQLSilk> | undefined,
+  input: GraphQLSilk | Record<string, GraphQLSilk> | undefined | void,
   options: EnsureInputOptions | undefined
 ): GraphQLFieldConfigArgumentMap | undefined {
   if (input === undefined) return undefined

--- a/packages/core/src/utils/context.ts
+++ b/packages/core/src/utils/context.ts
@@ -129,7 +129,6 @@ export class ContextMemoization<T> implements ContextMemoryOptions {
     if (!map.has(this.key)) {
       map.set(this.key, this.getter())
     }
-
     return map.get(this.key)
   }
 
@@ -178,7 +177,7 @@ export class ContextMemoization<T> implements ContextMemoryOptions {
 export interface CallableContextMemoization<T>
   extends Pick<
     ContextMemoization<T>,
-    "get" | "set" | "clear" | "exists" | "getter"
+    "get" | "set" | "clear" | "exists" | "getter" | "key"
   > {
   (): T
 }
@@ -192,6 +191,7 @@ export function createMemoization<T>(
   const memoization = new ContextMemoization(...args)
   const callable = () => memoization.get()
   return Object.assign(callable, {
+    key: memoization.key,
     get: () => memoization.get(),
     set: (value: T) => memoization.set(value),
     clear: () => memoization.clear(),
@@ -199,6 +199,6 @@ export function createMemoization<T>(
     getter: memoization.getter,
   } as Pick<
     ContextMemoization<T>,
-    "get" | "set" | "clear" | "exists" | "getter"
+    "get" | "set" | "clear" | "exists" | "getter" | "key"
   >)
 }


### PR DESCRIPTION
…of 'undefined'

- Modified type definitions in input.ts, resolver-chain-factory.ts, and related files to replace 'undefined' with 'void' for better type clarity and consistency.
- Adjusted interfaces and functions across the resolver to ensure compatibility with the new type definitions.
- Enhanced type safety in the resolver's input handling, improving overall code robustness.