### PR TITLE
feat(drizzle): DrizzleInputFactory to support custom column types

### DIFF
--- a/packages/drizzle/src/factory/input.ts
+++ b/packages/drizzle/src/factory/input.ts
@@ -226,7 +226,8 @@ export class DrizzleInputFactory<TTable extends Table> {
             return mapValue.SKIP
           }
           const type = (() => {
-            const t = DrizzleWeaver.getColumnType(column)
+            const fieldConfig = fieldsConfig[columnName]
+            const t = fieldConfig?.type ?? DrizzleWeaver.getColumnType(column)
             if (column.hasDefault) return t
             if (column.notNull && !isNonNullType(t))
               return new GraphQLNonNull(t)
@@ -305,7 +306,9 @@ export class DrizzleInputFactory<TTable extends Table> {
           ) {
             return mapValue.SKIP
           }
-          const type = DrizzleWeaver.getColumnType(column)
+          const type =
+            fieldsConfig[columnName]?.type ??
+            DrizzleWeaver.getColumnType(column)
           const columnConfig = fieldsConfig[columnName]
           return { type, description: columnConfig?.description }
         }),

--- a/packages/drizzle/test/input-factory.spec.ts
+++ b/packages/drizzle/test/input-factory.spec.ts
@@ -1,7 +1,7 @@
 import * as pg from "drizzle-orm/pg-core"
-import { printType } from "graphql"
+import { GraphQLScalarType, printType } from "graphql"
 import { describe, expect, it } from "vitest"
-import { DrizzleInputFactory } from "../src"
+import { DrizzleInputFactory, drizzleSilk } from "../src"
 import type { DrizzleFactoryInputVisibilityBehaviors } from "../src/types"
 
 describe("DrizzleInputFactory", () => {
@@ -188,6 +188,47 @@ describe("DrizzleInputFactory", () => {
           password: OrderDirection
           createdAt: OrderDirection
           updatedAt: OrderDirection
+        }"
+      `)
+    })
+  })
+
+  describe("custom column types", () => {
+    const EmailAddress = new GraphQLScalarType<string>({
+      name: "EmailAddress",
+      description: "A valid email address",
+      parseValue: (value) => String(value),
+      serialize: (value) => String(value),
+    })
+
+    const userTags = drizzleSilk(
+      pg.pgTable("userTags", {
+        id: pg.serial("id").primaryKey(),
+        email: pg.text("email").notNull(),
+      }),
+      {
+        fields: {
+          email: { type: EmailAddress },
+        },
+      }
+    )
+
+    const inputFactory = new DrizzleInputFactory(userTags)
+
+    it("should respect column types in InsertInput", () => {
+      expect(printType(inputFactory.insertInput())).toMatchInlineSnapshot(`
+        "type UserTagsInsertInput {
+          id: Int
+          email: EmailAddress!
+        }"
+      `)
+    })
+
+    it("should respect column types in UpdateInput", () => {
+      expect(printType(inputFactory.updateInput())).toMatchInlineSnapshot(`
+        "type UserTagsUpdateInput {
+          id: Int
+          email: EmailAddress
         }"
       `)
     })


### PR DESCRIPTION
- Updated DrizzleInputFactory to allow for custom field types defined in fieldsConfig, improving flexibility in input handling.
- Added tests to validate the correct application of custom types in InsertInput and UpdateInput, ensuring accurate GraphQL schema generation.