### PR TITLE
feat(prisma): add context module and useSelectedFields function

### DIFF
--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -16,6 +16,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./context": {
+      "import": {
+        "types": "./dist/context.d.ts",
+        "default": "./dist/context.js"
+      },
+      "require": {
+        "types": "./dist/context.d.cts",
+        "default": "./dist/context.cjs"
+      }
+    },
     "./generated": {
       "import": {
         "types": "./generated/index.d.ts",

--- a/packages/prisma/src/context.ts
+++ b/packages/prisma/src/context.ts
@@ -1,0 +1,32 @@
+import { useResolverPayload } from "@gqloom/core/context"
+import type { DMMF } from "@prisma/generator-helper"
+import type { PrismaModelSilk, SelectedModelFields } from "./types"
+import { getSelectedFields } from "./utils"
+
+/**
+ * Get the selected columns from the resolver payload
+ * @param silk - The silk to get the selected columns from
+ * @returns The selected columns
+ */
+export function useSelectedFields<
+  TSilk extends PrismaModelSilk<unknown, string, Record<string, unknown>>,
+>(silk: TSilk): SelectedModelFields<TSilk> /**
+ * Get the selected columns from the resolver payload
+ * @param silk - The silk to get the selected columns from
+ * @param payload - The resolver payload
+ * @returns The selected columns
+ */
+export function useSelectedFields(model: DMMF.Model): Record<string, boolean>
+/**
+ * Get the selected columns from the resolver payload
+ * @param silk - The silk to get the selected columns from
+ * @param payload - The resolver payload
+ * @returns The selected columns
+ */
+export function useSelectedFields(
+  silkOrModel:
+    | PrismaModelSilk<unknown, string, Record<string, unknown>>
+    | DMMF.Model
+): Record<string, boolean> {
+  return getSelectedFields(silkOrModel as any, useResolverPayload())
+}

--- a/packages/prisma/test/utils.spec.ts
+++ b/packages/prisma/test/utils.spec.ts
@@ -1,7 +1,9 @@
 import { field, query, silk, weave } from "@gqloom/core"
 import { resolver } from "@gqloom/core"
+import { asyncContextProvider } from "@gqloom/core/context"
 import { GraphQLString, execute, parse } from "graphql"
 import { beforeEach, describe, expect, it } from "vitest"
+import { useSelectedFields } from "../src/context"
 import { getSelectedFields } from "../src/utils"
 import { PrismaClient } from "./client"
 import * as silks from "./generated"
@@ -24,6 +26,48 @@ describe("getSelectedFields", () => {
   })
 
   const schema = weave(r)
+
+  beforeEach(() => {
+    selectedFields = {}
+  })
+
+  it("should access selected columns", async () => {
+    const query = parse(/* GraphQL */ `
+      query {
+        users {
+          id
+          name
+        }
+      }
+    `)
+    await execute({ schema, document: query })
+    expect(selectedFields).toMatchInlineSnapshot(`
+      {
+        "id": true,
+        "name": true,
+      }
+    `)
+  })
+})
+
+describe("useSelectedFields", () => {
+  const db = new PrismaClient()
+  let selectedFields: Record<string, boolean | undefined>
+  const r = resolver.of(silks.User, {
+    users: query(silks.User.list()).resolve(async () => {
+      selectedFields = useSelectedFields(silks.User)
+      const users = await db.user.findMany({
+        select: useSelectedFields(silks.User),
+      })
+      return users
+    }),
+
+    greeting: field(silk(GraphQLString))
+      .derivedFrom("name")
+      .resolve((user) => `Hello ${user.name}`),
+  })
+
+  const schema = weave(asyncContextProvider, r)
 
   beforeEach(() => {
     selectedFields = {}

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@gqloom/*": ["../../packages/*/src/index.ts"]
-    }
+    },
+    "module": "ESNext",
+    "moduleResolution": "bundler"
   },
   "include": ["src", "test"]
 }

--- a/packages/prisma/tsup.config.json
+++ b/packages/prisma/tsup.config.json
@@ -1,7 +1,8 @@
 {
   "entry": {
     "index": "./src/index.ts",
-    "generator": "./src/generator/index.ts"
+    "generator": "./src/generator/index.ts",
+    "context": "./src/context.ts"
   },
   "format": ["esm", "cjs"],
   "minify": false,


### PR DESCRIPTION
- Introduced a new context module with the `useSelectedFields` function to retrieve selected columns from the resolver payload.
- Updated `package.json` to include the new context module in the package exports.
- Modified `tsconfig.json` to set module resolution to "bundler" and module to "ESNext".
- Enhanced `tsup.config.json` to include the context entry point.
- Added tests for `useSelectedFields` to ensure correct functionality in selecting fields from GraphQL queries.