### PR TITLE
feat(federation): add Middlewares support for resolveReference

### DIFF
--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -270,6 +270,7 @@ export const asyncContextProvider: AsyncContextProvider = Object.assign(
       "field",
       "subscription.resolve",
       "subscription.subscribe",
+      "resolveReference",
     ],
     with: (...keyValues: [WeakKey, any][]) => {
       return createProvider(...keyValues)

--- a/packages/core/src/schema/schema-loom.ts
+++ b/packages/core/src/schema/schema-loom.ts
@@ -77,8 +77,14 @@ export class GraphQLSchemaLoom {
     return this
   }
 
-  public add(resolver: Loom.Resolver) {
-    provideWeaverContext(() => this.addResolver(resolver), this.context)
+  public add(
+    resolver: Loom.Resolver,
+    modifyParent?: (parent: LoomObjectType) => LoomObjectType
+  ) {
+    provideWeaverContext(
+      () => this.addResolver(resolver, modifyParent),
+      this.context
+    )
     return this
   }
 
@@ -130,10 +136,13 @@ export class GraphQLSchemaLoom {
     return schema
   }
 
-  protected addResolver(resolver: Loom.Resolver) {
+  protected addResolver(
+    resolver: Loom.Resolver,
+    modifyParent?: (parent: LoomObjectType) => LoomObjectType
+  ) {
     const resolverOptions = resolver["~meta"].options
     const parent = resolver["~meta"].parent
-    const parentObject = (() => {
+    let parentObject = (() => {
       if (parent == null) return undefined
       let gqlType = getGraphQLType(parent)
 
@@ -155,6 +164,8 @@ export class GraphQLSchemaLoom {
 
     if (resolverOptions?.extensions && parentObject)
       parentObject.mergeExtensions(resolverOptions.extensions)
+    if (modifyParent != null && parentObject)
+      parentObject = modifyParent(parentObject)
 
     Object.entries(resolver["~meta"].fields).forEach(([name, field]) => {
       if (field === FIELD_HIDDEN) {

--- a/packages/core/src/utils/middleware.ts
+++ b/packages/core/src/utils/middleware.ts
@@ -109,7 +109,7 @@ export function applyMiddlewares<
 
 export function filterMiddlewares(
   operation: MiddlewareOperation,
-  ...middlewareList: (Middleware | Middleware[] | undefined | null)[]
+  ...middlewareList: (Middleware | Iterable<Middleware> | undefined | null)[]
 ): Middleware[] {
   return middlewareList.reduce<Middleware[]>((acc, m) => {
     if (!m) return acc
@@ -123,6 +123,9 @@ export function filterMiddlewares(
   }, [])
 }
 
-function ensureArray<T>(value: T | T[]): T[] {
-  return Array.isArray(value) ? value : [value]
+function ensureArray<T>(value: T | Iterable<T>): T[] {
+  if (value != null && typeof value === "object" && Symbol.iterator in value) {
+    return Array.from(value)
+  }
+  return [value]
 }

--- a/packages/core/src/utils/middleware.ts
+++ b/packages/core/src/utils/middleware.ts
@@ -7,13 +7,22 @@ import type {
 } from "../resolver"
 import type { MayPromise, RequireKeys } from "./types"
 
-/** The operation of the field: `field`, `query`, `mutation`, `subscription.resolve` or `subscription.subscribe` */
+/**
+ * The operation of the field:
+ * - `field`
+ * - `query`
+ * - `mutation`
+ * - `subscription.resolve`
+ * - `subscription.subscribe`
+ * - `resolveReference`
+ */
 export type MiddlewareOperation =
   | "field"
   | "query"
   | "mutation"
   | "subscription.resolve"
   | "subscription.subscribe"
+  | "resolveReference"
 
 export interface MiddlewareOptions<
   TField extends Loom.BaseField = Loom.BaseField,

--- a/packages/federation/src/schema-weaver.ts
+++ b/packages/federation/src/schema-weaver.ts
@@ -11,6 +11,7 @@ import {
   type Loom,
   type Middleware,
   type WeaverConfig,
+  filterMiddlewares,
   query,
   resolver,
   silk,
@@ -26,6 +27,7 @@ import {
   lexicographicSortSchema,
 } from "graphql"
 import { mockAst } from "./mock-ast"
+import { FederatedChainResolver } from "./resolver"
 
 export class FederatedSchemaLoom extends GraphQLSchemaLoom {
   public override weaveGraphQLSchema(): GraphQLSchema {
@@ -109,7 +111,18 @@ export class FederatedSchemaLoom extends GraphQLSchemaLoom {
     weavers.forEach((it) => weaver.addVendor(it))
     configs.forEach((it) => weaver.setConfig(it))
     middlewares.forEach((it) => weaver.use(it))
-    resolvers.forEach((it) => weaver.add(it))
+    resolvers.forEach((it) =>
+      weaver.add(
+        it,
+        FederatedChainResolver.addResolveReference(
+          filterMiddlewares(
+            "resolveReference",
+            it["~meta"].options?.middlewares,
+            middlewares
+          )
+        )
+      )
+    )
     silks.forEach((it) => weaver.addType(it))
 
     return weaver.weaveGraphQLSchema()

--- a/packages/federation/test/schema.spec.ts
+++ b/packages/federation/test/schema.spec.ts
@@ -12,7 +12,7 @@ import {
 import { describe, expect, it } from "vitest"
 import { FederatedSchemaLoom, resolveReference, resolver } from "../src"
 
-describe("FederatedSchemaWeaver", () => {
+describe("FederatedSchemaLoom", () => {
   interface IUser {
     id: string
     name: string
@@ -44,13 +44,6 @@ describe("FederatedSchemaWeaver", () => {
     }
   )
 
-  const r2 = resolver
-    .of(User, {
-      me: loom.query(User, () => ({ id: "2", name: "@ava" })),
-    })
-    .directives({ key: { fields: "id", resolvable: true } })
-    .resolveReference(({ id }) => ({ id, name: "@ava" }))
-
   const schema = FederatedSchemaLoom.weave(
     r1,
     FederatedSchemaLoom.config({
@@ -67,6 +60,23 @@ describe("FederatedSchemaWeaver", () => {
     })
   )
 
+  const User2 = silk<IUser>(
+    new GraphQLObjectType({
+      name: "User",
+      fields: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+        name: { type: new GraphQLNonNull(GraphQLString) },
+      },
+    })
+  )
+
+  const r2 = resolver
+    .of(User2, {
+      me: loom.query(User2, () => ({ id: "2", name: "@ava" })),
+    })
+    .directives({ key: { fields: "id", resolvable: true } })
+    .resolveReference(({ id }) => ({ id, name: "@ava" }))
+
   const schema2 = FederatedSchemaLoom.weave(
     r2,
     FederatedSchemaLoom.config({
@@ -82,6 +92,7 @@ describe("FederatedSchemaWeaver", () => {
       },
     })
   )
+
   it("should weave a federated schema", () => {
     const federatedSdl = printSubgraphSchema(lexicographicSortSchema(schema))
     const federatedSdl2 = printSubgraphSchema(lexicographicSortSchema(schema2))
@@ -106,8 +117,6 @@ describe("FederatedSchemaWeaver", () => {
 
   it("should be able to print by graphql.js", () => {
     const sdl = printSchema(lexicographicSortSchema(schema))
-    const sdl2 = printSchema(lexicographicSortSchema(schema2))
-    expect(sdl2).toEqual(sdl)
     expect(sdl).toMatchInlineSnapshot(`
       "type Query {
         _entities(representations: [_Any!]!): [_Entity]!


### PR DESCRIPTION
- Updated the `MiddlewareOperation` type to include `resolveReference`.
- Enhanced the `FederatedChainResolver` to implement the `resolveReference` method with middleware support.
- Improved documentation for the `resolveReference` operation in the context of federated resolvers.