### PR TITLE
feat(drizzle): drizzle silk allow field types to be functions returning GraphQLOutputType or null

### DIFF
--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@gqloom/core": "workspace:*",
+    "@gqloom/valibot": "workspace:*",
     "@libsql/client": "^0.14.0",
     "@types/pg": "^8.11.10",
     "dotenv": "^16.4.7",

--- a/packages/drizzle/src/factory/input.ts
+++ b/packages/drizzle/src/factory/input.ts
@@ -227,7 +227,8 @@ export class DrizzleInputFactory<TTable extends Table> {
           }
           const type = (() => {
             const fieldConfig = fieldsConfig[columnName]
-            const t = fieldConfig?.type ?? DrizzleWeaver.getColumnType(column)
+            const t =
+              getValue(fieldConfig?.type) ?? DrizzleWeaver.getColumnType(column)
             if (column.hasDefault) return t
             if (column.notNull && !isNonNullType(t))
               return new GraphQLNonNull(t)
@@ -307,7 +308,7 @@ export class DrizzleInputFactory<TTable extends Table> {
             return mapValue.SKIP
           }
           const type =
-            fieldsConfig[columnName]?.type ??
+            getValue(fieldsConfig[columnName]?.type) ??
             DrizzleWeaver.getColumnType(column)
           const columnConfig = fieldsConfig[columnName]
           return { type, description: columnConfig?.description }

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -118,9 +118,10 @@ export class DrizzleWeaver {
           ...config,
           fields: mapValue(columns, (column, columnName) => {
             const fieldConfig = fieldsConfig[columnName]
-            let type = fieldConfig?.type ?? DrizzleWeaver.getColumnType(column)
+            const fieldType = getValue(fieldConfig?.type)
+            let type = fieldType ?? DrizzleWeaver.getColumnType(column)
 
-            if (fieldConfig?.type === null) return mapValue.SKIP
+            if (fieldType === null) return mapValue.SKIP
 
             if (column.notNull && !isNonNullType(type)) {
               type = new GraphQLNonNull(type)

--- a/packages/drizzle/src/types.ts
+++ b/packages/drizzle/src/types.ts
@@ -65,7 +65,11 @@ export interface DrizzleSilkConfig<TTable extends Table>
           /**
            * The type of the field, set to `null` to hide the field
            */
-          type?: GraphQLOutputType | null | undefined
+          type?:
+            | GraphQLOutputType
+            | null
+            | (() => GraphQLOutputType | null)
+            | undefined
         })
       | undefined
   }>

--- a/packages/drizzle/test/schema.spec.ts
+++ b/packages/drizzle/test/schema.spec.ts
@@ -1,4 +1,5 @@
-import { getGraphQLType, query, resolver, weave } from "@gqloom/core"
+import { getGraphQLType, query, resolver, silk, weave } from "@gqloom/core"
+import { ValibotWeaver } from "@gqloom/valibot"
 import { pgTable } from "drizzle-orm/pg-core"
 import * as pg from "drizzle-orm/pg-core"
 import { sqliteTable } from "drizzle-orm/sqlite-core"
@@ -11,6 +12,7 @@ import {
   printSchema,
   printType,
 } from "graphql"
+import * as v from "valibot"
 import { describe, expect, it } from "vitest"
 import { DrizzleWeaver, drizzleSilk } from "../src"
 
@@ -286,17 +288,34 @@ describe("drizzleSilk", () => {
         id: pg.serial().primaryKey(),
         name: pg.text(),
         hidden: pg.text(),
+        getter: pg.text(),
       }),
       {
         description: "some description of the foo",
         fields: {
           name: { description: "name of the foo" },
           hidden: { type: null },
+          getter: { type: () => silk.getType(v.date()) },
         },
       }
     )
 
-    const schema = weave(Foo)
+    const GraphQLDateTime = new GraphQLScalarType<Date, string>({
+      name: "DateTime",
+    })
+
+    const schema = weave(
+      Foo,
+      ValibotWeaver,
+      ValibotWeaver.config({
+        presetGraphQLType: (schema) => {
+          switch (schema.type) {
+            case "date":
+              return GraphQLDateTime
+          }
+        },
+      })
+    )
     expect(printSchema(schema)).toMatchInlineSnapshot(`
       """"some description of the foo"""
       type FooItem {
@@ -304,7 +323,10 @@ describe("drizzleSilk", () => {
 
         """name of the foo"""
         name: String
-      }"
+        getter: DateTime!
+      }
+
+      scalar DateTime"
     `)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       '@gqloom/core':
         specifier: workspace:*
         version: link:../core
+      '@gqloom/valibot':
+        specifier: workspace:*
+        version: link:../valibot
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -4190,7 +4193,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   light-my-request@5.13.0:


### PR DESCRIPTION
- Added @gqloom/valibot as a dependency in the drizzle package for improved validation capabilities.
- Updated type definitions to allow field types to be functions returning GraphQLOutputType or null.
- Modified the DrizzleWeaver class to utilize dynamic type getters for better flexibility in field configurations.
- Enhanced schema tests to validate the integration of ValibotWeaver and its configuration for custom GraphQL types.