### PR TITLE
feat(core): add setResult and clearResult methods to CallableInputParser

### DIFF
--- a/packages/core/src/resolver/input.spec.ts
+++ b/packages/core/src/resolver/input.spec.ts
@@ -158,6 +158,23 @@ describe("CallableInputParser", () => {
     expect(parseTime).toBe(1)
   })
 
+  it("should be able to set result", async () => {
+    const parseInput = createInputParser(
+      { count: silk(GraphQLInt) },
+      { count: 1 }
+    )
+    await parseInput()
+    expect(parseInput.result).toEqual({ value: { count: 1 } })
+    parseInput.setResult({ count: 2 })
+    expect(parseInput.result).toEqual({ value: { count: 2 } })
+    await parseInput()
+    expect(parseInput.result).toEqual({ value: { count: 2 } })
+
+    parseInput.result = { value: { count: 3 } }
+    await parseInput()
+    expect(parseInput.result).toEqual({ value: { count: 3 } })
+  })
+
   it("should be able to clear cache", async () => {
     let parseTime = 0
     const parseInput = createInputParser(
@@ -182,6 +199,10 @@ describe("CallableInputParser", () => {
     parseInput.result = undefined
     await parseInput()
     expect(parseTime).toBe(3)
+
+    parseInput.clearResult()
+    await parseInput()
+    expect(parseTime).toBe(4)
   })
 })
 

--- a/packages/core/src/resolver/input.ts
+++ b/packages/core/src/resolver/input.ts
@@ -55,6 +55,16 @@ export interface CallableInputParser<
    * Parse the input and return the result
    */
   getResult(): Promise<InferInputO<TSchema>>
+
+  /**
+   * Set the result's value of parsing
+   */
+  setResult(value: InferInputO<TSchema>): void
+
+  /**
+   * Clear the result of parsing, the parser will run again to get the result.
+   */
+  clearResult(): void
 }
 
 export function createInputParser<
@@ -75,6 +85,12 @@ export function createInputParser<
   })
   Object.defineProperty(parse, "getResult", {
     value: async () => getStandardValue(await parse()),
+  })
+  Object.defineProperty(parse, "setResult", {
+    value: (value: InferInputO<TSchema>) => (result = { value }),
+  })
+  Object.defineProperty(parse, "clearResult", {
+    value: () => (result = undefined),
   })
 
   return parse as unknown as CallableInputParser<TSchema>


### PR DESCRIPTION
- Implemented setResult method to allow setting the result's value after parsing.
- Added clearResult method to reset the result, enabling re-parsing.
- Updated tests to verify the functionality of the new methods.