### PR TITLE
feat(core): add output method for transformation for FactoryWithResolve

### DIFF
--- a/packages/core/src/resolver/resolver-chain-factory.spec.ts
+++ b/packages/core/src/resolver/resolver-chain-factory.spec.ts
@@ -1,0 +1,255 @@
+import {
+  GraphQLFloat,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { beforeEach, describe, expect, test } from "vitest"
+import "./resolver"
+import { applyMiddlewares } from "../utils"
+import { createInputParser } from "./input"
+import {
+  FieldFactoryWithResolve,
+  MutationFactoryWithResolve,
+  QueryFactoryWithResolve,
+} from "./resolver-chain-factory"
+import { silk } from "./silk"
+
+interface IGiraffe {
+  name: string
+  birthday: Date
+  heightInMeters: number
+}
+
+const Giraffe = silk<IGiraffe, IGiraffe>(
+  new GraphQLNonNull(
+    new GraphQLObjectType<IGiraffe>({
+      name: "Giraffe",
+      fields: {
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        birthday: { type: new GraphQLNonNull(GraphQLString) },
+        heightInMeters: { type: new GraphQLNonNull(GraphQLFloat) },
+      },
+    })
+  )
+)
+
+const GiraffeInput = silk<Partial<IGiraffe>>(
+  new GraphQLObjectType({
+    name: "GiraffeInput",
+    fields: {
+      name: { type: GraphQLString },
+      birthday: { type: GraphQLString },
+      heightInMeters: { type: GraphQLFloat },
+    },
+  })
+)
+
+// QueryFactoryWithResolve
+
+describe("QueryFactoryWithResolve", () => {
+  let Skyler: IGiraffe
+  beforeEach(() => {
+    Skyler = {
+      name: "Skyler",
+      birthday: new Date("2020-01-01"),
+      heightInMeters: 5,
+    }
+  })
+
+  test("input() should set input type", () => {
+    const q = new QueryFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const q2 = q.input(GiraffeInput)
+    expect(q2["~meta"].input).toBe(GiraffeInput)
+  })
+
+  test("output() should set output type and transform", async () => {
+    const q = new QueryFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const q2 = q.output(silk(GraphQLString), (g) => g.name)
+    const result = await applyMiddlewares(
+      {
+        outputSilk: q2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(q2["~meta"].input, undefined),
+        operation: "query",
+      },
+      () => q2["~meta"].resolve(undefined, undefined),
+      q2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler")
+  })
+
+  test("middlewares should apply transform", async () => {
+    const q = new QueryFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const q2 = q.output(silk(GraphQLString), (g) => g.name + "_transformed")
+    const result = await applyMiddlewares(
+      {
+        outputSilk: q2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(q2["~meta"].input, undefined),
+        operation: "query",
+      },
+      () => q2["~meta"].resolve(undefined, undefined),
+      q2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler_transformed")
+  })
+
+  test("description, deprecationReason, extensions", () => {
+    const q = new QueryFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+      .description("desc")
+      .deprecationReason("deprecated")
+      .extensions({ foo: "bar" })
+    expect(q["~meta"].description).toBe("desc")
+    expect(q["~meta"].deprecationReason).toBe("deprecated")
+    expect(q["~meta"].extensions).toEqual({ foo: "bar" })
+  })
+})
+
+describe("MutationFactoryWithResolve", () => {
+  let Skyler: IGiraffe
+  beforeEach(() => {
+    Skyler = {
+      name: "Skyler",
+      birthday: new Date("2020-01-01"),
+      heightInMeters: 5,
+    }
+  })
+
+  test("input() should set input type", () => {
+    const m = new MutationFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const m2 = m.input(GiraffeInput)
+    expect(m2["~meta"].input).toBe(GiraffeInput)
+  })
+
+  test("output() should set output type and transform", async () => {
+    const m = new MutationFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const m2 = m.output(silk(GraphQLString), (g) => g.name)
+    const result = await applyMiddlewares(
+      {
+        outputSilk: m2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(m2["~meta"].input, undefined),
+        operation: "mutation",
+      },
+      () => m2["~meta"].resolve(undefined, undefined),
+      m2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler")
+  })
+
+  test("middlewares should apply transform", async () => {
+    const m = new MutationFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const m2 = m.output(silk(GraphQLString), (g) => g.name + "_transformed")
+    const result = await applyMiddlewares(
+      {
+        outputSilk: m2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(m2["~meta"].input, undefined),
+        operation: "mutation",
+      },
+      () => m2["~meta"].resolve(undefined, undefined),
+      m2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler_transformed")
+  })
+
+  test("description, deprecationReason, extensions", () => {
+    const m = new MutationFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+      .description("desc")
+      .deprecationReason("deprecated")
+      .extensions({ foo: "bar" })
+    expect(m["~meta"].description).toBe("desc")
+    expect(m["~meta"].deprecationReason).toBe("deprecated")
+    expect(m["~meta"].extensions).toEqual({ foo: "bar" })
+  })
+})
+
+describe("FieldFactoryWithResolve", () => {
+  let Skyler: IGiraffe
+  beforeEach(() => {
+    Skyler = {
+      name: "Skyler",
+      birthday: new Date("2020-01-01"),
+      heightInMeters: 5,
+    }
+  })
+
+  test("output() should set output type and transform", async () => {
+    const f = new FieldFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const f2 = f.output(silk(GraphQLString), (g) => g.name)
+    const result = await applyMiddlewares(
+      {
+        outputSilk: f2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(f2["~meta"].input, undefined),
+        operation: "field",
+      },
+      () => f2["~meta"].resolve(undefined, undefined, undefined),
+      f2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler")
+  })
+
+  test("middlewares should apply transform", async () => {
+    const f = new FieldFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+    const f2 = f.output(silk(GraphQLString), (g) => g.name + "_transformed")
+    const result = await applyMiddlewares(
+      {
+        outputSilk: f2["~meta"].output,
+        parent: undefined,
+        payload: undefined,
+        parseInput: createInputParser(f2["~meta"].input, undefined),
+        operation: "field",
+      },
+      () => f2["~meta"].resolve(undefined, undefined, undefined),
+      f2["~meta"].middlewares ?? []
+    )
+    expect(result).toBe("Skyler_transformed")
+  })
+
+  test("description, deprecationReason, extensions", () => {
+    const f = new FieldFactoryWithResolve(Giraffe, {
+      resolve: () => Skyler,
+    })
+      .description("desc")
+      .deprecationReason("deprecated")
+      .extensions({ foo: "bar" })
+    expect(f["~meta"].description).toBe("desc")
+    expect(f["~meta"].deprecationReason).toBe("deprecated")
+    expect(f["~meta"].extensions).toEqual({ foo: "bar" })
+  })
+
+  test("FieldFactoryWithResolve", () => {
+    const field = new FieldFactoryWithResolve(silk(GraphQLString), {
+      resolve: () => "test",
+    })
+    expect(field).toBeDefined()
+    expect(field["~meta"].resolve).toBeDefined()
+  })
+})

--- a/packages/core/src/resolver/resolver-chain-factory.ts
+++ b/packages/core/src/resolver/resolver-chain-factory.ts
@@ -634,18 +634,18 @@ export class QueryFactoryWithResolve<
   implements Loom.Query<TOutput, TInput>
 {
   public get "~meta"(): Loom.Query<TOutput, TInput>["~meta"] {
-    return loom.query(this.output, this.options)["~meta"]
+    return loom.query(this.outputSilk, this.options)["~meta"]
   }
 
   public constructor(
-    protected output: TOutput,
+    protected outputSilk: TOutput,
     protected readonly options: QueryOptions<TOutput, TInput>
   ) {
     super(options)
   }
 
   protected clone(options?: Partial<typeof this.options> | undefined): this {
-    return new QueryFactoryWithResolve(this.output, {
+    return new QueryFactoryWithResolve(this.outputSilk, {
       ...this.options,
       ...options,
     }) as this
@@ -654,9 +654,24 @@ export class QueryFactoryWithResolve<
   public input<TInputNew extends GraphQLSilk<TInputO>>(
     input: TInputNew
   ): QueryFactoryWithResolve<TInputO, TOutput, TInputNew> {
-    return new QueryFactoryWithResolve(this.output, {
+    return new QueryFactoryWithResolve(this.outputSilk, {
       ...this.options,
       input,
+    } as QueryOptions<any, any>)
+  }
+
+  public output<TOutputNew extends GraphQLSilk>(
+    output: TOutputNew,
+    transform: (
+      output: StandardSchemaV1.InferOutput<TOutput>
+    ) => MayPromise<StandardSchemaV1.InferOutput<TOutputNew>>
+  ): QueryFactoryWithResolve<TInputO, TOutputNew, TInput> {
+    return new QueryFactoryWithResolve(output, {
+      ...this.options,
+      middlewares: [
+        ...(this.options.middlewares ?? []),
+        async (next) => transform(await next()),
+      ],
     } as QueryOptions<any, any>)
   }
 }
@@ -670,18 +685,18 @@ export class MutationFactoryWithResolve<
   implements Loom.Mutation<TOutput, TInput>
 {
   public get "~meta"(): Loom.Mutation<TOutput, TInput>["~meta"] {
-    return loom.mutation(this.output, this.options)["~meta"]
+    return loom.mutation(this.outputSilk, this.options)["~meta"]
   }
 
   public constructor(
-    protected output: TOutput,
+    protected outputSilk: TOutput,
     protected readonly options: MutationOptions<TOutput, TInput>
   ) {
     super(options)
   }
 
   protected clone(options?: Partial<typeof this.options> | undefined): this {
-    return new MutationFactoryWithResolve(this.output, {
+    return new MutationFactoryWithResolve(this.outputSilk, {
       ...this.options,
       ...options,
     }) as this
@@ -690,9 +705,24 @@ export class MutationFactoryWithResolve<
   public input<TInputNew extends GraphQLSilk<TInputO>>(
     input: TInputNew
   ): MutationFactoryWithResolve<TInputO, TOutput, TInputNew> {
-    return new MutationFactoryWithResolve(this.output, {
+    return new MutationFactoryWithResolve(this.outputSilk, {
       ...this.options,
       input,
+    } as MutationOptions<any, any>)
+  }
+
+  public output<TOutputNew extends GraphQLSilk>(
+    output: TOutputNew,
+    transform: (
+      output: StandardSchemaV1.InferOutput<TOutput>
+    ) => MayPromise<StandardSchemaV1.InferOutput<TOutputNew>>
+  ): MutationFactoryWithResolve<TInputO, TOutputNew, TInput> {
+    return new MutationFactoryWithResolve(output, {
+      ...this.options,
+      middlewares: [
+        ...(this.options.middlewares ?? []),
+        async (next) => transform(await next()),
+      ],
     } as MutationOptions<any, any>)
   }
 }
@@ -709,11 +739,11 @@ export class FieldFactoryWithResolve<
     undefined,
     string[] | undefined
   >["~meta"] {
-    return loom.field(this.output, this.options as any)["~meta"]
+    return loom.field(this.outputSilk, this.options as any)["~meta"]
   }
 
   public constructor(
-    protected output: TOutput,
+    protected outputSilk: TOutput,
     protected readonly options: FieldOptions<
       TParent,
       TOutput,
@@ -725,9 +755,24 @@ export class FieldFactoryWithResolve<
   }
 
   protected clone(options?: Partial<typeof this.options> | undefined): this {
-    return new FieldFactoryWithResolve(this.output, {
+    return new FieldFactoryWithResolve(this.outputSilk, {
       ...this.options,
       ...options,
     }) as this
+  }
+
+  public output<TOutputNew extends GraphQLSilk>(
+    output: TOutputNew,
+    transform: (
+      output: StandardSchemaV1.InferOutput<TOutput>
+    ) => MayPromise<StandardSchemaV1.InferOutput<TOutputNew>>
+  ): FieldFactoryWithResolve<TParent, TOutputNew> {
+    return new FieldFactoryWithResolve(output, {
+      ...this.options,
+      middlewares: [
+        ...(this.options.middlewares ?? []),
+        async (next) => transform(await next()),
+      ],
+    } as FieldOptions<any, any, any, any>)
   }
 }


### PR DESCRIPTION
- Updated the output property to outputSilk in QueryFactoryWithResolve, MutationFactoryWithResolve, and FieldFactoryWithResolve classes.
- Introduced a new output method in each class to allow transformation of the output with middleware support.