### PR TITLE
fix: add support for ZodPipe

### DIFF
--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -18,6 +18,7 @@ import type {
   $ZodNumber,
   $ZodObject,
   $ZodOptional,
+  $ZodPipe,
   $ZodShape,
   $ZodString,
   $ZodType,
@@ -145,6 +146,10 @@ export function isZodNullish(
   schema: unknown
 ): schema is $ZodOptional | $ZodNullable {
   return isZodOptional(schema) || isZodNullable(schema)
+}
+
+export function isZodPipe(schema: unknown): schema is $ZodPipe {
+  return isZodType(schema) && schema._zod.def.type === "pipe"
 }
 
 export function getDescription(schema: $ZodType): string | undefined {

--- a/packages/zod/test/schema.spec.ts
+++ b/packages/zod/test/schema.spec.ts
@@ -4,6 +4,9 @@ import {
   type Loom,
   type SchemaWeaver,
   collectNames,
+  field,
+  query,
+  resolver,
 } from "@gqloom/core"
 import {
   GraphQLBoolean,
@@ -28,9 +31,6 @@ import {
   asField,
   asObjectType,
   asUnionType,
-  field,
-  query,
-  resolver,
 } from "../src"
 import { resolveTypeByDiscriminatedUnion } from "../src/utils"
 
@@ -62,6 +62,15 @@ describe("ZodWeaver", () => {
     expect(getGraphQLType(z.boolean().default(false).nullable())).toEqual(
       GraphQLBoolean
     )
+
+    expect(
+      getGraphQLType(
+        z
+          .boolean()
+          .nullable()
+          .transform((x) => x ?? false)
+      )
+    ).toEqual(GraphQLBoolean)
 
     expect(getGraphQLType(z.date().nullable())).toEqual(GraphQLString)
 

--- a/packages/zod/test/v3/schema.spec.ts
+++ b/packages/zod/test/v3/schema.spec.ts
@@ -62,6 +62,15 @@ describe("ZodWeaver", () => {
       GraphQLBoolean
     )
 
+    expect(
+      getGraphQLType(
+        z
+          .boolean()
+          .nullable()
+          .transform((x) => x ?? false)
+      )
+    ).toEqual(GraphQLBoolean)
+
     expect(getGraphQLType(z.date().nullable())).toEqual(GraphQLString)
 
     expect(


### PR DESCRIPTION
- Implemented isZodPipe utility function to identify ZodPipe types.
- Updated toNullableGraphQLType and toMemoriedGraphQLType methods to handle ZodPipe schemas correctly.
- Enhanced test cases to validate the new functionality for nullable boolean transformations.