### PR TITLE
Avoid using double underscore (__) prefixes for internal alias names to conform with the GraphQL specification

### DIFF
--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -1,3 +1,3 @@
 export const DERIVED_DEPENDENCIES = "loom.derived-from-dependencies"
 
-export const AUTO_ALIASING = "__gqloom_auto_aliasing"
+export const AUTO_ALIASING = "_gqloom_auto_aliasing"


### PR DESCRIPTION
 **Context**: While using GQLoom's `resolver.of()` to define relation fields, the library generates internal alias names such as `__gqloom_auto_aliasingAuthor`. These names are directly exposed in the generated GraphQL schema. GraphQL Yoga and other `graphql-js` implementations reject the schema because such names begin with a double underscore.

**Specification**: The GraphQL specification states that any name within a GraphQL type system **must not start with two underscores** unless it is part of the introspection system. The only valid double-underscore names are internal meta‑fields like `__typename`, `__schema` and `__type`; user‑defined names should never use that prefix.

https://spec.graphql.org/October2021/#sec-Introspection.Reserved-Names

**Problem**: GQLoom currently prefixes its auto‑generated alias fields with `__gqloom_`, causing names like `__gqloom_auto_aliasing` to leak into the schema. This violates the reserved-name rule above and results in errors such as "Name '**gqloom_auto_aliasingAuthor' must not begin with '__'"

alternative fix: Store internal alias information in GraphQL `extensions` metadata rather than as visible fields, so it never appears in the public schema.
