### PR TITLE
fix(zod): enhance GraphQL type handling for default values

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -93,7 +93,7 @@ export class ZodWeaver {
     const gqlType = ZodWeaver.toMemoriedGraphQLType(schema)
 
     const isNullable = (
-      ["null", "nullable", "optional"] as $ZodTypeDef["type"][]
+      ["null", "nullable", "optional", "default"] as $ZodTypeDef["type"][]
     ).includes(schema._zod.def.type)
     if (isNullable) return gqlType
 

--- a/packages/zod/test/schema.spec.ts
+++ b/packages/zod/test/schema.spec.ts
@@ -74,6 +74,8 @@ describe("ZodWeaver", () => {
 
     expect(getGraphQLType(z.date().nullable())).toEqual(GraphQLString)
 
+    expect(getGraphQLType(z.int().default(10))).toEqual(GraphQLInt)
+
     expect(getGraphQLType(z.cuid().nullable())).toEqual(GraphQLID)
     expect(getGraphQLType(z.cuid2().nullable())).toEqual(GraphQLID)
     expect(getGraphQLType(z.ulid().nullable())).toEqual(GraphQLID)


### PR DESCRIPTION
- Updated ZodWeaver to include "default" in the list of nullable types.
- Added test case to validate GraphQL type conversion for Zod integer with a default value.