### PR TITLE
feat(mikro): accept ResolverPayload in getEntityManager

### DIFF
--- a/packages/mikro-orm/src/factory/type.ts
+++ b/packages/mikro-orm/src/factory/type.ts
@@ -4,6 +4,7 @@ import type {
   MayPromise,
   MutationFactoryWithResolve,
   QueryFactoryWithResolve,
+  ResolverPayload,
 } from "@gqloom/core"
 import type {
   Collection,
@@ -28,7 +29,9 @@ import type {
 } from "@mikro-orm/core"
 
 export interface MikroResolverFactoryOptions<TEntity extends object> {
-  getEntityManager: () => MayPromise<EntityManager>
+  getEntityManager: (
+    payload: ResolverPayload | undefined
+  ) => MayPromise<EntityManager>
   input?: MikroFactoryPropertyBehaviors<TEntity>
   metadata?: MetadataStorage
 }


### PR DESCRIPTION
- Modified the getEntityManager method to accept an optional ResolverPayload parameter.
- Updated all resolver methods to pass the payload to the entity manager for improved context handling.