### PR TITLE
fix(drizzle): generate per-enum filter input types for pg enum columns (rqbv2)

### DIFF
--- a/examples/drizzle/schema.graphql
+++ b/examples/drizzle/schema.graphql
@@ -65,7 +65,7 @@ input UsersFilters {
   createdAt: PgTimestampFilters
   email: PgTextFilters
   name: PgTextFilters
-  role: PgEnumColumnFilters
+  role: RoleFilters
   OR: [UsersFiltersOr!]
 }
 
@@ -166,7 +166,7 @@ input PgTextFiltersOr {
   isNotNull: Boolean
 }
 
-input PgEnumColumnFilters {
+input RoleFilters {
   eq: Role
   ne: Role
   lt: Role
@@ -177,10 +177,10 @@ input PgEnumColumnFilters {
   notInArray: [Role!]
   isNull: Boolean
   isNotNull: Boolean
-  OR: [PgEnumColumnFiltersOr!]
+  OR: [RoleFiltersNested!]
 }
 
-input PgEnumColumnFiltersOr {
+input RoleFiltersNested {
   eq: Role
   ne: Role
   lt: Role
@@ -198,7 +198,7 @@ input UsersFiltersOr {
   createdAt: PgTimestampFilters
   email: PgTextFilters
   name: PgTextFilters
-  role: PgEnumColumnFilters
+  role: RoleFilters
 }
 
 input PostsOrderBy {

--- a/packages/drizzle/src/factory/input.ts
+++ b/packages/drizzle/src/factory/input.ts
@@ -435,11 +435,12 @@ export class DrizzleInputFactory<TTable extends Table> {
   }
 
   protected static columnFilters(column: Column) {
-    const name = `${pascalCase(column.columnType)}Filters`
+    const gqlType = DrizzleWeaver.getColumnType(column)
+    const baseName = DrizzleInputFactory.columnFiltersBaseName(column, gqlType)
+    const name = `${baseName}Filters`
     const existing = weaverContext.getNamedType(name) as GraphQLObjectType
     if (existing != null) return existing
 
-    const gqlType = DrizzleWeaver.getColumnType(column)
     const gqlListType = new GraphQLList(new GraphQLNonNull(gqlType))
     const baseFields: Record<string, GraphQLFieldConfig<any, any, any>> = {
       eq: { type: gqlType },
@@ -461,7 +462,7 @@ export class DrizzleInputFactory<TTable extends Table> {
     }
 
     const filtersNested = new GraphQLObjectType({
-      name: `${pascalCase(column.columnType)}FiltersNested`,
+      name: `${baseName}FiltersNested`,
       fields: { ...baseFields },
     })
 
@@ -476,6 +477,14 @@ export class DrizzleInputFactory<TTable extends Table> {
         },
       })
     )
+  }
+
+  protected static columnFiltersBaseName(
+    column: Column,
+    gqlType: ReturnType<typeof DrizzleWeaver.getColumnType>
+  ) {
+    if (gqlType instanceof GraphQLEnumType) return gqlType.name
+    return pascalCase(column.columnType)
   }
 
   public orderBy() {

--- a/packages/drizzle/test/input-factory.spec.ts
+++ b/packages/drizzle/test/input-factory.spec.ts
@@ -1,10 +1,25 @@
-import { field, initWeaverContext, provideWeaverContext } from "@gqloom/core"
+import { field, initWeaverContext, provideWeaverContext, weave } from "@gqloom/core"
 import { ValibotWeaver } from "@gqloom/valibot"
+import { defineRelations } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/node-postgres"
 import * as pg from "drizzle-orm/pg-core"
-import { GraphQLScalarType, printType } from "graphql"
+import {
+  GraphQLEnumType,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  lexicographicSortSchema,
+  parse,
+  printSchema,
+  printType,
+  validate,
+} from "graphql"
 import * as v from "valibot"
 import { describe, expect, it } from "vitest"
-import { DrizzleInputFactory, drizzleSilk } from "../src"
+import {
+  DrizzleInputFactory,
+  drizzleResolverFactory,
+  drizzleSilk,
+} from "../src"
 import type { DrizzleFactoryInputBehaviors } from "../src/types"
 
 describe("DrizzleInputFactory", () => {
@@ -251,6 +266,153 @@ describe("DrizzleInputFactory", () => {
           email: EmailAddress
         }"
       `)
+    })
+  })
+
+  describe("pg enum column filters", () => {
+    const genderEnum = pg.pgEnum("gender", ["MALE", "FEMALE", "OTHER"])
+    const employeeStatusEnum = pg.pgEnum("employee_status", [
+      "probation",
+      "active",
+      "resigned",
+    ])
+    const contractTypeEnum = pg.pgEnum("contract_type", [
+      "full_time",
+      "part_time",
+      "intern",
+    ])
+    const maritalStatusEnum = pg.pgEnum("marital_status", [
+      "single",
+      "married",
+      "divorced",
+    ])
+
+    const employees = drizzleSilk(
+      pg.pgTable("employees", {
+        id: pg.uuid("id").defaultRandom().primaryKey(),
+        name: pg.varchar("name", { length: 50 }).notNull(),
+        gender: genderEnum("gender"),
+        maritalStatus: maritalStatusEnum("marital_status"),
+        status: employeeStatusEnum("status").notNull().default("probation"),
+        contractType: contractTypeEnum("contract_type"),
+      }),
+      { name: "Employee" }
+    )
+
+    it("should type each enum column filter with its own enum", () => {
+      const inputFactory = new DrizzleInputFactory(employees)
+      const filtersType = inputFactory.filters()
+      const filtersNestedType = filtersType.getFields().OR.type as any
+      const filtersNestedFields = (
+        filtersNestedType.ofType.ofType as GraphQLObjectType
+      ).getFields()
+
+      const genderFilters = filtersNestedFields.gender.type as GraphQLObjectType
+      const statusFilters = filtersNestedFields.status.type as GraphQLObjectType
+      const contractTypeFilters = filtersNestedFields.contractType
+        .type as GraphQLObjectType
+      const maritalStatusFilters = filtersNestedFields.maritalStatus
+        .type as GraphQLObjectType
+
+      expect(genderFilters.name).toBe("GenderFilters")
+      expect(statusFilters.name).toBe("EmployeeStatusFilters")
+      expect(contractTypeFilters.name).toBe("ContractTypeFilters")
+      expect(maritalStatusFilters.name).toBe("MaritalStatusFilters")
+
+      expect(
+        (genderFilters.getFields().eq.type as GraphQLEnumType).name
+      ).toBe("Gender")
+      expect(
+        (statusFilters.getFields().eq.type as GraphQLEnumType).name
+      ).toBe("EmployeeStatus")
+      expect(
+        (contractTypeFilters.getFields().eq.type as GraphQLEnumType).name
+      ).toBe("ContractType")
+      expect(
+        (maritalStatusFilters.getFields().eq.type as GraphQLEnumType).name
+      ).toBe("MaritalStatus")
+    })
+
+    it("should generate distinct filter input types per enum in woven schema", () => {
+      const schema = { employees }
+      const relations = defineRelations(schema, () => ({}))
+      const db = drizzle("postgres://localhost/test", { relations })
+      const gqlSchema = weave(drizzleResolverFactory(db, employees).resolver())
+      const printed = printSchema(lexicographicSortSchema(gqlSchema))
+
+      expect(printed).toContain("input GenderFilters")
+      expect(printed).toContain("input EmployeeStatusFilters")
+      expect(printed).toContain("input ContractTypeFilters")
+      expect(printed).toContain("input MaritalStatusFilters")
+      expect(printed).not.toContain("PgEnumColumnFilters")
+
+      expect(printed).toMatch(/input GenderFilters[\s\S]*?eq: Gender/)
+      expect(printed).toMatch(
+        /input EmployeeStatusFilters[\s\S]*?eq: EmployeeStatus/
+      )
+      expect(printed).toMatch(
+        /input ContractTypeFilters[\s\S]*?eq: ContractType/
+      )
+      expect(printed).toMatch(
+        /input MaritalStatusFilters[\s\S]*?eq: MaritalStatus/
+      )
+    })
+
+    it("should validate filter variables against the correct enum", () => {
+      const schema = { employees }
+      const relations = defineRelations(schema, () => ({}))
+      const db = drizzle("postgres://localhost/test", { relations })
+      const gqlSchema = weave(drizzleResolverFactory(db, employees).resolver())
+
+      const validQuery = parse(/* GraphQL */ `
+        query {
+          employees(where: { status: { eq: ACTIVE } }) {
+            status
+          }
+        }
+      `)
+      expect(validate(gqlSchema, validQuery)).toEqual([])
+
+      const invalidQuery = parse(/* GraphQL */ `
+        query {
+          employees(where: { status: { eq: MALE } }) {
+            status
+          }
+        }
+      `)
+      expect(
+        validate(gqlSchema, invalidQuery).map((error) => error.message)
+      ).toEqual(['Value "MALE" does not exist in "EmployeeStatus" enum.'])
+    })
+
+    it("should reuse the same filter type for columns sharing an enum", () => {
+      const roleEnum = pg.pgEnum("role", ["admin", "user"])
+
+      const users = drizzleSilk(
+        pg.pgTable("users", {
+          id: pg.serial("id").primaryKey(),
+          role: roleEnum("role"),
+        })
+      )
+      const posts = drizzleSilk(
+        pg.pgTable("posts", {
+          id: pg.serial("id").primaryKey(),
+          authorRole: roleEnum("author_role"),
+        })
+      )
+
+      const schema = { users, posts }
+      const relations = defineRelations(schema, () => ({}))
+      const db = drizzle("postgres://localhost/test", { relations })
+      const gqlSchema = weave(
+        drizzleResolverFactory(db, users).resolver(),
+        drizzleResolverFactory(db, posts).resolver()
+      )
+      const printed = printSchema(lexicographicSortSchema(gqlSchema))
+
+      expect(printed.match(/^input RoleFilters \{/m)?.length).toBe(1)
+      expect(printed).toContain("role: RoleFilters")
+      expect(printed).toContain("authorRole: RoleFilters")
     })
   })
 })

--- a/website/content/home/drizzle.md
+++ b/website/content/home/drizzle.md
@@ -225,7 +225,7 @@ input UsersFilters {
   createdAt: PgTimestampFilters
   email: PgTextFilters
   name: PgTextFilters
-  role: PgEnumColumnFilters
+  role: RoleFilters
   OR: [UsersFiltersOr!]
 }
 
@@ -326,7 +326,7 @@ input PgTextFiltersOr {
   isNotNull: Boolean
 }
 
-input PgEnumColumnFilters {
+input RoleFilters {
   eq: Role
   ne: Role
   lt: Role
@@ -337,10 +337,10 @@ input PgEnumColumnFilters {
   notInArray: [Role!]
   isNull: Boolean
   isNotNull: Boolean
-  OR: [PgEnumColumnFiltersOr!]
+  OR: [RoleFiltersNested!]
 }
 
-input PgEnumColumnFiltersOr {
+input RoleFiltersNested {
   eq: Role
   ne: Role
   lt: Role
@@ -358,7 +358,7 @@ input UsersFiltersOr {
   createdAt: PgTimestampFilters
   email: PgTextFilters
   name: PgTextFilters
-  role: PgEnumColumnFilters
+  role: RoleFilters
 }
 
 input PostsOrderBy {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backport of the fix for #378 onto the `drizzle-rqbv2` branch.

When using `drizzleResolverFactory`, all PostgreSQL enum columns incorrectly shared a single `PgEnumColumnFilters` input type. The first enum column processed determined the `eq`/`ne`/`in` field types for every other enum column on the same table.

This PR changes enum column filter caching to use the GraphQL enum name (e.g. `GenderFilters`, `EmployeeStatusFilters`) instead of the Drizzle column type (`PgEnumColumn`).

## Root cause

`columnFilters()` cached filter input types by `column.columnType`. All PostgreSQL enum columns share the same Drizzle column type (`PgEnumColumn`), so only the first enum column's GraphQL type was used for every subsequent enum filter.

## Changes

- Derive filter input names from the GraphQL enum type when the column resolves to a `GraphQLEnumType`
- Use `${enumName}FiltersNested` for nested filter objects (matching rqbv2 naming)
- Keep existing behavior for non-enum columns (`PgTextFilters`, `PgSerialFilters`, etc.)
- Add regression tests in `packages/drizzle/test/input-factory.spec.ts`
- Update example/documentation schema snapshots (`PgEnumColumnFilters` → `RoleFilters`)

## Breaking change

`PgEnumColumnFilters` is replaced with per-enum filter types such as `GenderFilters` and `EmployeeStatusFilters`. Clients that referenced `PgEnumColumnFilters` directly will need to update.

## Test plan

- [x] `pnpm exec vitest run test/input-factory.spec.ts test/schema.spec.ts test/helper.spec.ts` in `packages/drizzle`
- [x] Verified `employees(where: { status: { eq: ACTIVE } })` validates successfully and `eq: MALE` is rejected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a177b09b-ba6d-4e78-8b57-1cd6e05b21f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a177b09b-ba6d-4e78-8b57-1cd6e05b21f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

