### PR TITLE
ci: 用 GitHub Actions 检查文档站能否构建

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,20 @@ jobs:
         env:
           MYSQL_URL: mysql://root@localhost:3306/mysql
           POSTGRESQL_URL: postgresql://postgres@localhost:5432/postgres
+
+  website:
+    name: Build documentation website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: ./.github/actions/pnpm
+      - name: Build packages
+        run: pnpm run build
+      - name: Generate
+        run: pnpm -r run generate
+      - name: Build website
+        run: pnpm --filter website build
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node --max_old_space_size=8192 ./node_modules/vitepress/bin/vitepress.js dev",
-    "build": "vitepress build",
+    "build": "node --max_old_space_size=8192 ./node_modules/vitepress/bin/vitepress.js build",
     "preview": "vitepress preview",
     "check:type": "concurrently 'pnpm run check:type:*'",
     "check:type:root": "tsgo --noEmit",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

文档站在 `website/` 中用 VitePress 构建，示例代码会经过 Twoslash 类型检查。现有 CI 只做 lint、类型检查和单测，文档站本身构建失败不会被拦住。

## 改动

在 `.github/workflows/test.yml` 中新增 `website` job，在 PR 和 `publish.yml` 调用的 Test workflow 里并行运行：

1. 安装依赖
2. `pnpm run build`（先编好 `@gqloom/*`，供 Twoslash 解析）
3. `pnpm -r run generate`（与 type-check 一致，补齐 Prisma 等生成产物）
4. `pnpm --filter website build`

同时把 `website` 的 `build` 脚本改成和 `dev` 一样提高 Node 堆上限（`--max_old_space_size=8192`），避免 Twoslash 在构建时 OOM。

## 验证方式

本地等价命令：

```bash
pnpm install
pnpm run build
pnpm -r run generate
pnpm --filter website build
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

