### PR TITLE
ci: deploy documentation website to Vercel from main

### DIFF
--- a/.github/scripts/package-vercel-output.js
+++ b/.github/scripts/package-vercel-output.js
@@ -1,0 +1,34 @@
+const fs = require("node:fs")
+const path = require("node:path")
+
+const dist = path.join("website", ".vitepress", "dist")
+const out = path.join(".vercel", "output")
+const staticDir = path.join(out, "static")
+
+if (!fs.existsSync(dist) || !fs.statSync(dist).isDirectory()) {
+  console.error(`Missing ${dist}; website build did not produce output`)
+  process.exit(1)
+}
+
+fs.rmSync(out, { recursive: true, force: true })
+fs.mkdirSync(out, { recursive: true })
+fs.cpSync(dist, staticDir, { recursive: true })
+
+const config = {
+  version: 3,
+  routes: [
+    {
+      src: "/assets/(.*)",
+      headers: {
+        "cache-control": "public, max-age=31536000, immutable",
+      },
+    },
+    { handle: "filesystem" },
+    { src: "/(.*)", status: 404, dest: "/404.html" },
+  ],
+}
+
+fs.writeFileSync(
+  path.join(out, "config.json"),
+  `${JSON.stringify(config, null, 2)}\n`
+)

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,14 +1,3 @@
-# Production docs deploy for https://gqloom.vercel.app
-# (Vercel project: https://vercel.com/xcfoxs-projects/gqloom)
-#
-# Required repository secrets:
-#   VERCEL_TOKEN        Account token from https://vercel.com/account/settings/tokens
-#   VERCEL_ORG_ID       Team / org id from the Vercel project settings
-#   VERCEL_PROJECT_ID   Project id from the Vercel project settings
-#
-# Also turn off Vercel Git auto-deploys for this project so only this workflow
-# publishes production. vercel.json sets git.deploymentEnabled to false.
-
 name: Deploy documentation
 
 on:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,105 @@
+# Production docs deploy for https://gqloom.vercel.app
+# (Vercel project: https://vercel.com/xcfoxs-projects/gqloom)
+#
+# Required repository secrets:
+#   VERCEL_TOKEN        Account token from https://vercel.com/account/settings/tokens
+#   VERCEL_ORG_ID       Team / org id from the Vercel project settings
+#   VERCEL_PROJECT_ID   Project id from the Vercel project settings
+#
+# Also turn off Vercel Git auto-deploys for this project so only this workflow
+# publishes production. vercel.json sets git.deploymentEnabled to false.
+
+name: Deploy documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-website-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  NODE_OPTIONS: --max_old_space_size=8192
+
+jobs:
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Vercel secrets
+        run: |
+          missing=0
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing GitHub Actions secret $name"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Add VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID as repository secrets, then re-run this workflow."
+            exit 1
+          fi
+
+      - name: Setup pnpm
+        uses: ./.github/actions/pnpm
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Generate
+        run: pnpm -r run generate
+
+      - name: Build website
+        run: pnpm --filter website build
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel project
+        run: vercel pull --yes --environment=production
+
+      - name: Package Vercel output
+        run: |
+          dist=website/.vitepress/dist
+          out=.vercel/output
+          if [ ! -d "$dist" ]; then
+            echo "::error::Missing $dist; website build did not produce output"
+            exit 1
+          fi
+          rm -rf "$out"
+          mkdir -p "$out/static"
+          cp -a "$dist"/. "$out/static/"
+          cat > "$out/config.json" <<'EOF'
+          {
+            "version": 3,
+            "routes": [
+              {
+                "src": "/assets/(.*)",
+                "headers": {
+                  "cache-control": "public, max-age=31536000, immutable"
+                }
+              },
+              { "handle": "filesystem" },
+              { "src": "/(.*)", "status": 404, "dest": "/404.html" }
+            ]
+          }
+          EOF
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod --yes | tail -n1)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed to $url"

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -71,31 +71,7 @@ jobs:
         run: vercel pull --yes --environment=production
 
       - name: Package Vercel output
-        run: |
-          dist=website/.vitepress/dist
-          out=.vercel/output
-          if [ ! -d "$dist" ]; then
-            echo "::error::Missing $dist; website build did not produce output"
-            exit 1
-          fi
-          rm -rf "$out"
-          mkdir -p "$out/static"
-          cp -a "$dist"/. "$out/static/"
-          cat > "$out/config.json" <<'EOF'
-          {
-            "version": 3,
-            "routes": [
-              {
-                "src": "/assets/(.*)",
-                "headers": {
-                  "cache-control": "public, max-age=31536000, immutable"
-                }
-              },
-              { "handle": "filesystem" },
-              { "src": "/(.*)", "status": 404, "dest": "/404.html" }
-            ]
-          }
-          EOF
+        run: node .github/scripts/package-vercel-output.js
 
       - name: Deploy to Vercel
         id: deploy

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm run build && pnpm -r run generate && pnpm --filter website build",
+  "outputDirectory": "website/.vitepress/dist",
+  "git": {
+    "deploymentEnabled": false
+  },
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why GitHub Actions (instead of only Vercel Git)

This repo is a pnpm monorepo. The VitePress site needs:

1. `pnpm run build` for `@gqloom/*`
2. `pnpm -r run generate` (Prisma, etc.)
3. `pnpm --filter website build` with a large Node heap (Twoslash)

Vercel’s native Git build is a poor fit for that pipeline. GitHub Actions builds the site, then uploads the static output to the existing Vercel project with `vercel deploy --prebuilt --prod`.

## What landed

- `.github/workflows/deploy-website.yml` — on push to `main` (and `workflow_dispatch`), build and deploy
- `.github/scripts/package-vercel-output.js` — copy `website/.vitepress/dist` into Vercel Build Output API layout
- `vercel.json` — `git.deploymentEnabled: false` so Vercel Git does not also build on every commit

The workflow expects repository secrets `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID`. Until they exist, the job fails on the “Check Vercel secrets” step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

