### PR TITLE
ci: skip duplicate documentation website build on main

### DIFF
--- a/.github/scripts/package-vercel-output.js
+++ b/.github/scripts/package-vercel-output.js
@@ -1,8 +1,16 @@
 const fs = require("node:fs")
 const path = require("node:path")
 
+const orgId = process.env.VERCEL_ORG_ID
+const projectId = process.env.VERCEL_PROJECT_ID
+if (!orgId || !projectId) {
+  console.error("Missing VERCEL_ORG_ID or VERCEL_PROJECT_ID")
+  process.exit(1)
+}
+
 const dist = path.join("website", ".vitepress", "dist")
-const out = path.join(".vercel", "output")
+const vercelDir = ".vercel"
+const out = path.join(vercelDir, "output")
 const staticDir = path.join(out, "static")
 
 if (!fs.existsSync(dist) || !fs.statSync(dist).isDirectory()) {
@@ -13,6 +21,10 @@ if (!fs.existsSync(dist) || !fs.statSync(dist).isDirectory()) {
 fs.rmSync(out, { recursive: true, force: true })
 fs.mkdirSync(out, { recursive: true })
 fs.cpSync(dist, staticDir, { recursive: true })
+fs.writeFileSync(
+  path.join(vercelDir, "project.json"),
+  `${JSON.stringify({ orgId, projectId }, null, 2)}\n`
+)
 
 const config = {
   version: 3,

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -56,9 +56,6 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
-      - name: Pull Vercel project
-        run: vercel pull --yes --environment=production
-
       - name: Package Vercel output
         run: node .github/scripts/package-vercel-output.js
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           POSTGRESQL_URL: postgresql://postgres@localhost:5432/postgres
 
   website:
+    if: github.event_name == 'pull_request'
     name: Build documentation website
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Duplicate docs build

After #384 and #385, a push to `main` built the VitePress site twice. This PR runs **Build documentation website** only on `pull_request`. Deploy documentation still builds once on `main`.

## Vercel deploy failure

[This run](https://github.com/modevol-com/gqloom/actions/runs/32210547090/job/95942242447) failed at `vercel pull` with “Could not retrieve Project Settings”.

Cause: a project-scoped Vercel token can read the project, but the CLI also requests `/v2/user` and the team, which return 404/403. `vercel pull` then aborts.

Fix: stop calling `vercel pull`. Write `.vercel/project.json` from `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` and `vercel deploy --prebuilt --prod`.

After merge, re-run **Deploy documentation** on `main` (or push to `main`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

