### PR TITLE
ci: compress Vercel docs uploads with --archive=tgz

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -62,6 +62,6 @@ jobs:
       - name: Deploy to Vercel
         id: deploy
         run: |
-          url=$(vercel deploy --prebuilt --prod --yes | tail -n1)
+          url=$(vercel deploy --prebuilt --prod --yes --archive=tgz | tail -n1)
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed to $url"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`vercel deploy --prebuilt` was uploading VitePress output as individual files (~139MB). The site dist is large mainly because Twoslash embeds types into per-page JS.

This adds `--archive=tgz` so the CLI gzip-compresses the Build Output API payload before upload.

After merge, the next **Deploy documentation** run should show a much smaller upload size.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02d8b8f0-d22c-4afc-b24b-5a98bf2febca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

