### PR TITLE
fix(drizzle): mysql2 callback pool and rc.4 type mapping for CI

### DIFF
--- a/examples/cattery-valibot/src/index.ts
+++ b/examples/cattery-valibot/src/index.ts
@@ -1,10 +1,11 @@
-import { createServer } from "node:http"
 import * as fs from "node:fs"
+import { createServer } from "node:http"
 import * as path from "node:path"
 import { type Middleware, weave } from "@gqloom/core"
 import { asyncContextProvider } from "@gqloom/core/context"
 import { DrizzleWeaver } from "@gqloom/drizzle"
 import { ValibotWeaver } from "@gqloom/valibot"
+import { extractExtendedColumnType } from "drizzle-orm"
 import { GraphQLError, printSchema } from "graphql"
 import { GraphQLDateTime, GraphQLJSONObject } from "graphql-scalars"
 import { createYoga } from "graphql-yoga"
@@ -30,10 +31,11 @@ const schema = weave(
   exceptionFilter,
   DrizzleWeaver.config({
     presetGraphQLType(column) {
-      if (column.dataType === "date") {
+      const { constraint } = extractExtendedColumnType(column)
+      if (constraint === "date") {
         return GraphQLDateTime
       }
-      if (column.dataType === "json") {
+      if (constraint === "json") {
         return GraphQLJSONObject
       }
     },

--- a/packages/drizzle/test/resolver-factory.spec.ts
+++ b/packages/drizzle/test/resolver-factory.spec.ts
@@ -23,6 +23,7 @@ import {
 } from "drizzle-orm/node-postgres"
 import * as sqlite from "drizzle-orm/sqlite-core"
 import { execute, parse } from "graphql"
+import { createPool } from "mysql2"
 import * as v from "valibot"
 import {
   afterAll,
@@ -1578,17 +1579,29 @@ describe
   .runIf(config.mysqlUrl)
   .concurrent("DrizzleMySQLResolverFactory", () => {
     let db: MySql2Database<typeof mysqlRelations>
+    let mysqlClient: ReturnType<typeof createPool>
     let userFactory: DrizzleMySQLResolverFactory<
       typeof db,
       typeof mysqlSchemas.users
     >
 
     beforeAll(async () => {
-      db = mysqlDrizzle(config.mysqlUrl, {
+      // drizzle-orm 1.0.0-rc.4 writes `client.config.supportBigNumbers`. A URL
+      // argument uses mysql2/promise.createPool(), whose PromisePool has no
+      // `.config`. Pass the callback pool as `client` instead.
+      mysqlClient = createPool(config.mysqlUrl)
+      db = mysqlDrizzle({
+        client: mysqlClient,
         relations: mysqlRelations,
       })
       userFactory = drizzleResolverFactory(db, mysqlSchemas.users)
       await db.execute(sql`select 1`)
+    })
+
+    afterAll(async () => {
+      await new Promise<void>((resolve, reject) => {
+        mysqlClient.end((err: Error | null) => (err ? reject(err) : resolve()))
+      })
     })
 
     describe("insertArrayMutation", () => {

--- a/packages/drizzle/test/resolver-mysql.spec.ts
+++ b/packages/drizzle/test/resolver-mysql.spec.ts
@@ -8,6 +8,7 @@ import {
   printSchema,
 } from "graphql"
 import { createYoga, type YogaServerInstance } from "graphql-yoga"
+import { createPool } from "mysql2"
 import * as v from "valibot"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { config } from "../env.config"
@@ -17,6 +18,7 @@ import { relations } from "./schema/mysql-relations"
 
 describe.runIf(config.mysqlUrl)("resolver by mysql", () => {
   let db: MySql2Database<typeof relations>
+  let mysqlClient: ReturnType<typeof createPool>
   let logs: string[] = []
   let gqlSchema: GraphQLSchema
   let yoga: YogaServerInstance<{}, {}>
@@ -44,7 +46,12 @@ describe.runIf(config.mysqlUrl)("resolver by mysql", () => {
 
   beforeAll(async () => {
     try {
-      db = drizzle(config.mysqlUrl, {
+      // drizzle-orm 1.0.0-rc.4 writes `client.config.supportBigNumbers`. A URL
+      // argument uses mysql2/promise.createPool(), whose PromisePool has no
+      // `.config`. Pass the callback pool as `client` instead.
+      mysqlClient = createPool(config.mysqlUrl)
+      db = drizzle({
+        client: mysqlClient,
         relations,
         logger: { logQuery: (query) => logs.push(query) },
       })
@@ -93,6 +100,9 @@ describe.runIf(config.mysqlUrl)("resolver by mysql", () => {
   afterAll(async () => {
     await db.delete(posts)
     await db.delete(users)
+    await new Promise<void>((resolve, reject) => {
+      mysqlClient.end((err: Error | null) => (err ? reject(err) : resolve()))
+    })
   })
 
   it("should weave GraphQL schema correctly", async () => {

--- a/website/docs/schema/drizzle.md
+++ b/website/docs/schema/drizzle.md
@@ -893,15 +893,17 @@ To adapt to more Drizzle types, we can extend GQLoom to add more type mappings.
 First, we use `DrizzleWeaver.config` to define the configuration of type mapping. Here we import `GraphQLDateTime` and `GraphQLJSONObject` from [graphql-scalars](https://the-guild.dev/graphql/scalars). When encountering `date` and `json` types, we map them to the corresponding GraphQL scalars.
 
 ```ts twoslash
+import { extractExtendedColumnType } from "drizzle-orm"
 import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
 import { DrizzleWeaver } from "@gqloom/drizzle"
 
 const drizzleWeaverConfig = DrizzleWeaver.config({
   presetGraphQLType: (column) => {
-    if (column.dataType === "date") {
+    const { constraint } = extractExtendedColumnType(column)
+    if (constraint === "date") {
       return GraphQLDateTime
     }
-    if (column.dataType === "json") {
+    if (constraint === "json") {
       return GraphQLJSON
     }
   },

--- a/website/zh/docs/schema/drizzle.md
+++ b/website/zh/docs/schema/drizzle.md
@@ -893,15 +893,17 @@ const usersResolver = usersResolverFactory.resolver()
 首先我们使用 `DrizzleWeaver.config` 来定义类型映射的配置。这里我们导入来自 [graphql-scalars](https://the-guild.dev/graphql/scalars) 的 `GraphQLDateTime` 和  `GraphQLJSONObject` ，当遇到 `date` 和 `json` 类型时，我们将其映射到对应的 GraphQL 标量。
 
 ```ts twoslash
+import { extractExtendedColumnType } from "drizzle-orm"
 import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
 import { DrizzleWeaver } from "@gqloom/drizzle"
 
 const drizzleWeaverConfig = DrizzleWeaver.config({
   presetGraphQLType: (column) => {
-    if (column.dataType === "date") {
+    const { constraint } = extractExtendedColumnType(column)
+    if (constraint === "date") {
       return GraphQLDateTime
     }
-    if (column.dataType === "json") {
+    if (constraint === "json") {
       return GraphQLJSON
     }
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix CI failures on `drizzle-rqbv2` after merging the rc.4 PR.

## Unit tests (`Run Uint test`)

`drizzle-orm@1.0.0-rc.4`'s mysql2 driver does `client.config.supportBigNumbers = true`. Passing a connection URL uses `mysql2/promise.createPool()`, and that PromisePool has **no** `.config`, so construct throws:

```
TypeError: Cannot set properties of undefined (setting 'supportBigNumbers')
```

That is why `resolver-mysql.spec.ts` and `DrizzleMySQLResolverFactory` failed in CI (Postgres/SQLite were fine). The follow-on `db.delete` / `yoga.fetch` errors are just `db` staying undefined after that crash.

**Fix:** create a callback `mysql2` pool with `createPool(url)` and pass it as `{ client }`.

## Docs website build

Twoslash in `website/docs/schema/drizzle.md` (and the Chinese page) compared `column.dataType === "date" | "json"`. In rc.4 those are constraints, not `ColumnType` values, so TS2367 failed the VitePress build.

**Fix:** use `extractExtendedColumnType(column).constraint`, same as the drizzle package tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c02109c2-f62a-471f-8211-65d8f405501e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c02109c2-f62a-471f-8211-65d8f405501e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

