### PR TITLE
docs(drizzle): 中英文文档对齐，同时保留 Relational API v1 / v2

### DIFF
--- a/website/docs/schema/drizzle.md
+++ b/website/docs/schema/drizzle.md
@@ -10,6 +10,8 @@ import { Tabs } from '@/components/tabs'
 - Use Drizzle Table as [Silk](../silk);
 - Use the resolver factory to quickly create CRUD operations from Drizzle.
 
+`@gqloom/drizzle` supports Drizzle Relational Query API v1 (`drizzle-orm` 0.x, `@gqloom/drizzle`) and v2 (`drizzle-orm` 1.0, `@gqloom/drizzle@rc`). Use the **Relational API v1 / v2** tabs to switch examples; they stay in sync across this page.
+
 ## Installation
 
 <!--@include: ../../snippets/install-drizzle.md-->
@@ -18,172 +20,33 @@ import { Tabs } from '@/components/tabs'
 
 We can easily use Drizzle Schemas as [Silk](../silk) by simply wrapping them with `drizzleSilk`.
 
-```ts twoslash title="schema.ts" tab="schema.ts"
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-silk-schema.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-```
+</template>
+<template #Relational_API_v1>
 
-```ts twoslash title="relations.ts" tab="relations.ts"
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<!--@include: @/snippets/drizzle/v1-silk-schema.md-->
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
-
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-// ---cut---
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
-
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-```
+</template>
+</Tabs>
 
 Let's use them in the resolver. At the same time, we use the `useSelectedColumns()` function to know which columns are needed for the current GraphQL query: 
 
-```ts twoslash title="resolver.ts"
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-silk-resolver.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
+</template>
+<template #Relational_API_v1>
 
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-// ---cut---
-import { field, query, resolver } from "@gqloom/core"
-import { useSelectedColumns } from "@gqloom/drizzle/context"
-import { eq, inArray } from "drizzle-orm"
-import { drizzle } from "drizzle-orm/libsql"
-import * as v from "valibot"
-import { relations } from "./relations"
-import { posts, users } from "./schema"
+<!--@include: @/snippets/drizzle/v1-silk-resolver.md-->
 
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-export const usersResolver = resolver.of(users, {
-  user: query
-    .output(users.$nullable())
-    .input({ id: v.number() })
-    .resolve(({ id }) => {
-      return db
-        .select(useSelectedColumns(users))
-        .from(users)
-        .where(eq(users.id, id))
-        .get()
-    }),
-
-  users: query.output(users.$list()).resolve(() => {
-    return db.select(useSelectedColumns(users)).from(users).all()
-  }),
-
-  posts: field
-    .output(posts.$list())
-    .derivedFrom("id")
-    .load(async (userList) => {
-      const postList = await db
-        .select()
-        .from(posts)
-        .where(
-          inArray(
-            users.id,
-            userList.map((user) => user.id)
-          )
-        )
-      const groups = new Map<number, (typeof posts.$inferSelect)[]>()
-
-      for (const post of postList) {
-        const key = post.authorId
-        if (key == null) continue
-        groups.set(key, [...(groups.get(key) ?? []), post])
-      }
-      return userList.map((user) => groups.get(user.id) ?? [])
-    }),
-})
-```
+</template>
+</Tabs>
 
 As shown in the code above, we can directly use the Drizzle Table wrapped by `drizzleSilk` in the `resolver`. 
 Here, we use `users` as the parent type of `resolver.of`, and define two queries named `user` and `users` and a field named `posts` in the resolver. Among them:
@@ -296,78 +159,12 @@ Sometimes we use `json`, `enum` columns in database tables, and we want to corre
 <Tabs groupId="drizzle-api-version">
 <template #Relational_API_v2>
 
-```ts [schema.ts]
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { drizzle } from "drizzle-orm/libsql"
-import { relations } from "./relations"
-import { users } from "./schema"
-
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-```
+<!--@include: @/snippets/drizzle/v2-factory-intro.md-->
 
 </template>
 <template #Relational_API_v1>
 
-```ts twoslash [schema.ts]
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
-
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
-
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
-
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-// ---cut---
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { drizzle } from "drizzle-orm/libsql"
-import { relations } from "./relations"
-import { users } from "./schema"
-
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-```
+<!--@include: @/snippets/drizzle/v1-factory-intro.md-->
 
 </template>
 </Tabs>
@@ -376,114 +173,18 @@ const usersResolverFactory = drizzleResolverFactory(db, users)
 
 In Drizzle Table, we can easily create [relationships](https://orm.drizzle.team/docs/relations). We can use the `relationField` method of the resolver factory to create corresponding GraphQL fields for relationships.
 
-```ts twoslash [resolver.ts]
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-relation-field.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
+</template>
+<template #Relational_API_v1>
 
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-import { field, EasyDataLoader } from "@gqloom/core"
-import { createMemoization } from "@gqloom/core/context"
-import { posts } from "schema"
-// ---cut---
-import { query, resolver } from "@gqloom/core"
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { eq, inArray } from "drizzle-orm"
-import { drizzle } from "drizzle-orm/libsql"
-import * as v from "valibot"
-import { relations } from "./relations"
-import { users } from "./schema"
+<!--@include: @/snippets/drizzle/v1-relation-field.md-->
 
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-
-const usePostsLoader = createMemoization( // [!code --]
-  () => // [!code --]
-    new EasyDataLoader< // [!code --]
-      { id: number }, // [!code --]
-      (typeof posts.$inferSelect)[] // [!code --]
-    >(async (userList) => { // [!code --]
-      const postList = await db // [!code --]
-        .select() // [!code --]
-        .from(posts) // [!code --]
-        .where( // [!code --]
-          inArray( // [!code --]
-            users.id, // [!code --]
-            userList.map((user) => user.id) // [!code --]
-          ) // [!code --]
-        ) // [!code --]
-      const groups = new Map<number, (typeof posts.$inferSelect)[]>() // [!code --]
-      // [!code --]
-      for (const post of postList) { // [!code --]
-        const key = post.authorId // [!code --]
-        if (key == null) continue // [!code --]
-        groups.set(key, [...(groups.get(key) ?? []), post]) // [!code --]
-      } // [!code --]
-      return userList.map((user) => groups.get(user.id) ?? []) // [!code --]
-    }) // [!code --]
-) // [!code --]
- 
-export const usersResolver = resolver.of(users, {
-  user: query
-    .output(users.$nullable())
-    .input({ id: v.number() })
-    .resolve(({ id }) => {
-      return db.select().from(users).where(eq(users.id, id)).get()
-    }),
-
-  users: query.output(users.$list()).resolve(() => {
-    return db.select().from(users).all()
-  }),
-
-  posts_: field.output(posts.$list()) // [!code --]
-    .derivedFrom('id') // [!code --]
-    .resolve((user) => { // [!code --]
-      return usePostsLoader().load(user) // [!code --]
-    }), // [!code --]
-
-  posts: usersResolverFactory.relationField("posts"), // [!code ++]
-})
-```
+</template>
+</Tabs>
 
 ### Queries
 
@@ -492,6 +193,8 @@ The Drizzle resolver factory pre-defines some commonly used queries:
 - `selectArrayQuery`: Find multiple records in the corresponding table according to the conditions.
 - `selectSingleQuery`: Find a single record in the corresponding table according to the conditions.
 - `countQuery`: Count the number of records in the corresponding table according to the conditions.
+
+The query and mutation factories below use the same GQLoom API on both Relational API versions. Schema and `db` setup follow the version selected in the tabs above.
 
 We can use the queries from the resolver factory in the resolver:
 
@@ -892,23 +595,18 @@ To adapt to more Drizzle types, we can extend GQLoom to add more type mappings.
 
 First, we use `DrizzleWeaver.config` to define the configuration of type mapping. Here we import `GraphQLDateTime` and `GraphQLJSONObject` from [graphql-scalars](https://the-guild.dev/graphql/scalars). When encountering `date` and `json` types, we map them to the corresponding GraphQL scalars.
 
-```ts twoslash
-import { extractExtendedColumnType } from "drizzle-orm"
-import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
-import { DrizzleWeaver } from "@gqloom/drizzle"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-const drizzleWeaverConfig = DrizzleWeaver.config({
-  presetGraphQLType: (column) => {
-    const { constraint } = extractExtendedColumnType(column)
-    if (constraint === "date") {
-      return GraphQLDateTime
-    }
-    if (constraint === "json") {
-      return GraphQLJSON
-    }
-  },
-})
-```
+<!--@include: @/snippets/drizzle/v2-type-mapping.md-->
+
+</template>
+<template #Relational_API_v1>
+
+<!--@include: @/snippets/drizzle/v1-type-mapping.md-->
+
+</template>
+</Tabs>
 
 Pass the configuration to the `weave` function when weaving the GraphQL Schema:
 
@@ -920,15 +618,17 @@ export const schema = weave(drizzleWeaverConfig, usersResolver, postsResolver)
 
 ## Default Type Mapping
 
-The following table lists the default mapping relationships between Drizzle `dataType` and GraphQL types in GQLoom:
+The following table lists the default mapping relationships between Drizzle types and GraphQL types in GQLoom:
 
-| Drizzle `dataType` | GraphQL Type     |
-| ------------------ | ---------------- |
-| boolean            | `GraphQLBoolean` |
-| number             | `GraphQLFloat`   |
-| json               | `GraphQLString`  |
-| date               | `GraphQLString`  |
-| bigint             | `GraphQLString`  |
-| string             | `GraphQLString`  |
-| buffer             | `GraphQLList`    |
-| array              | `GraphQLList`    |
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
+
+<!--@include: @/snippets/drizzle/v2-default-mapping.md-->
+
+</template>
+<template #Relational_API_v1>
+
+<!--@include: @/snippets/drizzle/v1-default-mapping.md-->
+
+</template>
+</Tabs>

--- a/website/snippets/drizzle/v1-default-mapping.md
+++ b/website/snippets/drizzle/v1-default-mapping.md
@@ -1,0 +1,10 @@
+| Drizzle `dataType` | GraphQL Type     |
+| ------------------ | ---------------- |
+| boolean            | `GraphQLBoolean` |
+| number             | `GraphQLFloat`   |
+| json               | `GraphQLString`  |
+| date               | `GraphQLString`  |
+| bigint             | `GraphQLString`  |
+| string             | `GraphQLString`  |
+| buffer             | `GraphQLList`    |
+| array              | `GraphQLList`    |

--- a/website/snippets/drizzle/v1-factory-intro.md
+++ b/website/snippets/drizzle/v1-factory-intro.md
@@ -1,0 +1,13 @@
+```ts
+import { drizzleResolverFactory } from "@gqloom/drizzle"
+import { drizzle } from "drizzle-orm/libsql"
+import * as schema from "./schema"
+import { users } from "./schema"
+
+const db = drizzle({
+  schema,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+const usersResolverFactory = drizzleResolverFactory(db, users)
+```

--- a/website/snippets/drizzle/v1-relation-field.md
+++ b/website/snippets/drizzle/v1-relation-field.md
@@ -1,0 +1,64 @@
+```ts [resolver.ts]
+import { EasyDataLoader, field, query, resolver } from "@gqloom/core"
+import { createMemoization } from "@gqloom/core/context"
+import { drizzleResolverFactory } from "@gqloom/drizzle"
+import { eq, inArray } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/libsql"
+import * as v from "valibot"
+import * as schema from "./schema"
+import { posts, users } from "./schema"
+
+const db = drizzle({
+  schema,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+const usersResolverFactory = drizzleResolverFactory(db, users)
+
+const usePostsLoader = createMemoization( // [!code --]
+  () => // [!code --]
+    new EasyDataLoader< // [!code --]
+      { id: number }, // [!code --]
+      (typeof posts.$inferSelect)[] // [!code --]
+    >(async (userList) => { // [!code --]
+      const postList = await db // [!code --]
+        .select() // [!code --]
+        .from(posts) // [!code --]
+        .where( // [!code --]
+          inArray( // [!code --]
+            users.id, // [!code --]
+            userList.map((user) => user.id) // [!code --]
+          ) // [!code --]
+        ) // [!code --]
+      const groups = new Map<number, (typeof posts.$inferSelect)[]>() // [!code --]
+      // [!code --]
+      for (const post of postList) { // [!code --]
+        const key = post.authorId // [!code --]
+        if (key == null) continue // [!code --]
+        groups.set(key, [...(groups.get(key) ?? []), post]) // [!code --]
+      } // [!code --]
+      return userList.map((user) => groups.get(user.id) ?? []) // [!code --]
+    }) // [!code --]
+) // [!code --]
+
+export const usersResolver = resolver.of(users, {
+  user: query
+    .output(users.$nullable())
+    .input({ id: v.number() })
+    .resolve(({ id }) => {
+      return db.select().from(users).where(eq(users.id, id)).get()
+    }),
+
+  users: query.output(users.$list()).resolve(() => {
+    return db.select().from(users).all()
+  }),
+
+  posts_: field.output(posts.$list()) // [!code --]
+    .derivedFrom('id') // [!code --]
+    .resolve((user) => { // [!code --]
+      return usePostsLoader().load(user) // [!code --]
+    }), // [!code --]
+
+  posts: usersResolverFactory.relationField("posts"), // [!code ++]
+})
+```

--- a/website/snippets/drizzle/v1-silk-resolver.md
+++ b/website/snippets/drizzle/v1-silk-resolver.md
@@ -1,0 +1,54 @@
+```ts title="resolver.ts"
+import { field, query, resolver } from "@gqloom/core"
+import { useSelectedColumns } from "@gqloom/drizzle/context"
+import { eq, inArray } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/libsql"
+import * as v from "valibot"
+import * as schema from "./schema"
+import { posts, users } from "./schema"
+
+const db = drizzle({
+  schema,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+export const usersResolver = resolver.of(users, {
+  user: query
+    .output(users.$nullable())
+    .input({ id: v.number() })
+    .resolve(({ id }) => {
+      return db
+        .select(useSelectedColumns(users))
+        .from(users)
+        .where(eq(users.id, id))
+        .get()
+    }),
+
+  users: query.output(users.$list()).resolve(() => {
+    return db.select(useSelectedColumns(users)).from(users).all()
+  }),
+
+  posts: field
+    .output(posts.$list())
+    .derivedFrom("id")
+    .load(async (userList) => {
+      const postList = await db
+        .select()
+        .from(posts)
+        .where(
+          inArray(
+            users.id,
+            userList.map((user) => user.id)
+          )
+        )
+      const groups = new Map<number, (typeof posts.$inferSelect)[]>()
+
+      for (const post of postList) {
+        const key = post.authorId
+        if (key == null) continue
+        groups.set(key, [...(groups.get(key) ?? []), post])
+      }
+      return userList.map((user) => groups.get(user.id) ?? [])
+    }),
+})
+```

--- a/website/snippets/drizzle/v1-silk-schema.md
+++ b/website/snippets/drizzle/v1-silk-schema.md
@@ -1,0 +1,35 @@
+```ts title="schema.ts"
+import { drizzleSilk } from "@gqloom/drizzle"
+import { relations } from "drizzle-orm"
+import * as t from "drizzle-orm/sqlite-core"
+
+export const users = drizzleSilk(
+  t.sqliteTable("users", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    name: t.text().notNull(),
+    age: t.int(),
+    email: t.text(),
+    password: t.text(),
+  })
+)
+
+export const usersRelations = relations(users, ({ many }) => ({
+  posts: many(posts),
+}))
+
+export const posts = drizzleSilk(
+  t.sqliteTable("posts", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    title: t.text().notNull(),
+    content: t.text(),
+    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
+  })
+)
+
+export const postsRelations = relations(posts, ({ one }) => ({
+  author: one(users, {
+    fields: [posts.authorId],
+    references: [users.id],
+  }),
+}))
+```

--- a/website/snippets/drizzle/v1-type-mapping.md
+++ b/website/snippets/drizzle/v1-type-mapping.md
@@ -1,0 +1,15 @@
+```ts
+import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
+import { DrizzleWeaver } from "@gqloom/drizzle"
+
+const drizzleWeaverConfig = DrizzleWeaver.config({
+  presetGraphQLType: (column) => {
+    if (column.dataType === "date") {
+      return GraphQLDateTime
+    }
+    if (column.dataType === "json") {
+      return GraphQLJSON
+    }
+  },
+})
+```

--- a/website/snippets/drizzle/v2-default-mapping.md
+++ b/website/snippets/drizzle/v2-default-mapping.md
@@ -1,0 +1,8 @@
+| Drizzle `type` (`extractExtendedColumnType`) | GraphQL Type     |
+| -------------------------------------------- | ---------------- |
+| boolean                                      | `GraphQLBoolean` |
+| number                                       | `GraphQLInt` / `GraphQLFloat` |
+| bigint, string, custom                       | `GraphQLString`  |
+| object (json / date)                         | `GraphQLString`  |
+| object (buffer)                              | `GraphQLList`    |
+| array                                        | `GraphQLList`    |

--- a/website/snippets/drizzle/v2-factory-intro.md
+++ b/website/snippets/drizzle/v2-factory-intro.md
@@ -1,0 +1,13 @@
+```ts
+import { drizzleResolverFactory } from "@gqloom/drizzle"
+import { drizzle } from "drizzle-orm/libsql"
+import { relations } from "./relations"
+import { users } from "./schema"
+
+const db = drizzle({
+  relations,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+const usersResolverFactory = drizzleResolverFactory(db, users)
+```

--- a/website/snippets/drizzle/v2-relation-field.md
+++ b/website/snippets/drizzle/v2-relation-field.md
@@ -1,0 +1,108 @@
+```ts twoslash [resolver.ts]
+// @filename: schema.ts
+import { drizzleSilk } from "@gqloom/drizzle"
+import * as t from "drizzle-orm/sqlite-core"
+
+export const users = drizzleSilk(
+  t.sqliteTable("users", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    name: t.text().notNull(),
+    age: t.int(),
+    email: t.text(),
+    password: t.text(),
+  })
+)
+
+export const posts = drizzleSilk(
+  t.sqliteTable("posts", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    title: t.text().notNull(),
+    content: t.text(),
+    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
+  })
+)
+// @filename: relations.ts
+import { defineRelations } from "drizzle-orm"
+import * as tables from "./schema"
+
+export const relations = defineRelations(tables, (r) => ({
+  users: {
+    posts: r.many.posts({
+      from: r.users.id,
+      to: r.posts.authorId,
+    }),
+  },
+  posts: {
+    author: r.one.users({
+      from: r.posts.authorId,
+      to: r.users.id,
+    }),
+  },
+}))
+// @filename: resolver.ts
+import { field, EasyDataLoader } from "@gqloom/core"
+import { createMemoization } from "@gqloom/core/context"
+import { posts } from "schema"
+// ---cut---
+import { query, resolver } from "@gqloom/core"
+import { drizzleResolverFactory } from "@gqloom/drizzle"
+import { eq, inArray } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/libsql"
+import * as v from "valibot"
+import { relations } from "./relations"
+import { users } from "./schema"
+
+const db = drizzle({
+  relations,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+const usersResolverFactory = drizzleResolverFactory(db, users)
+
+const usePostsLoader = createMemoization( // [!code --]
+  () => // [!code --]
+    new EasyDataLoader< // [!code --]
+      { id: number }, // [!code --]
+      (typeof posts.$inferSelect)[] // [!code --]
+    >(async (userList) => { // [!code --]
+      const postList = await db // [!code --]
+        .select() // [!code --]
+        .from(posts) // [!code --]
+        .where( // [!code --]
+          inArray( // [!code --]
+            users.id, // [!code --]
+            userList.map((user) => user.id) // [!code --]
+          ) // [!code --]
+        ) // [!code --]
+      const groups = new Map<number, (typeof posts.$inferSelect)[]>() // [!code --]
+      // [!code --]
+      for (const post of postList) { // [!code --]
+        const key = post.authorId // [!code --]
+        if (key == null) continue // [!code --]
+        groups.set(key, [...(groups.get(key) ?? []), post]) // [!code --]
+      } // [!code --]
+      return userList.map((user) => groups.get(user.id) ?? []) // [!code --]
+    }) // [!code --]
+) // [!code --]
+ 
+export const usersResolver = resolver.of(users, {
+  user: query
+    .output(users.$nullable())
+    .input({ id: v.number() })
+    .resolve(({ id }) => {
+      return db.select().from(users).where(eq(users.id, id)).get()
+    }),
+
+  users: query.output(users.$list()).resolve(() => {
+    return db.select().from(users).all()
+  }),
+
+  posts_: field.output(posts.$list()) // [!code --]
+    .derivedFrom('id') // [!code --]
+    .resolve((user) => { // [!code --]
+      return usePostsLoader().load(user) // [!code --]
+    }), // [!code --]
+
+  posts: usersResolverFactory.relationField("posts"), // [!code ++]
+})
+```

--- a/website/snippets/drizzle/v2-silk-resolver.md
+++ b/website/snippets/drizzle/v2-silk-resolver.md
@@ -1,0 +1,96 @@
+```ts twoslash title="resolver.ts"
+// @filename: schema.ts
+import { drizzleSilk } from "@gqloom/drizzle"
+import * as t from "drizzle-orm/sqlite-core"
+
+export const users = drizzleSilk(
+  t.sqliteTable("users", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    name: t.text().notNull(),
+    age: t.int(),
+    email: t.text(),
+    password: t.text(),
+  })
+)
+
+export const posts = drizzleSilk(
+  t.sqliteTable("posts", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    title: t.text().notNull(),
+    content: t.text(),
+    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
+  })
+)
+// @filename: relations.ts
+import { defineRelations } from "drizzle-orm"
+import * as tables from "./schema"
+
+export const relations = defineRelations(tables, (r) => ({
+  users: {
+    posts: r.many.posts({
+      from: r.users.id,
+      to: r.posts.authorId,
+    }),
+  },
+  posts: {
+    author: r.one.users({
+      from: r.posts.authorId,
+      to: r.users.id,
+    }),
+  },
+}))
+// @filename: resolver.ts
+// ---cut---
+import { field, query, resolver } from "@gqloom/core"
+import { useSelectedColumns } from "@gqloom/drizzle/context"
+import { eq, inArray } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/libsql"
+import * as v from "valibot"
+import { relations } from "./relations"
+import { posts, users } from "./schema"
+
+const db = drizzle({
+  relations,
+  connection: { url: process.env.DB_FILE_NAME! },
+})
+
+export const usersResolver = resolver.of(users, {
+  user: query
+    .output(users.$nullable())
+    .input({ id: v.number() })
+    .resolve(({ id }) => {
+      return db
+        .select(useSelectedColumns(users))
+        .from(users)
+        .where(eq(users.id, id))
+        .get()
+    }),
+
+  users: query.output(users.$list()).resolve(() => {
+    return db.select(useSelectedColumns(users)).from(users).all()
+  }),
+
+  posts: field
+    .output(posts.$list())
+    .derivedFrom("id")
+    .load(async (userList) => {
+      const postList = await db
+        .select()
+        .from(posts)
+        .where(
+          inArray(
+            users.id,
+            userList.map((user) => user.id)
+          )
+        )
+      const groups = new Map<number, (typeof posts.$inferSelect)[]>()
+
+      for (const post of postList) {
+        const key = post.authorId
+        if (key == null) continue
+        groups.set(key, [...(groups.get(key) ?? []), post])
+      }
+      return userList.map((user) => groups.get(user.id) ?? [])
+    }),
+})
+```

--- a/website/snippets/drizzle/v2-silk-schema.md
+++ b/website/snippets/drizzle/v2-silk-schema.md
@@ -1,0 +1,67 @@
+```ts twoslash title="schema.ts" tab="schema.ts"
+import { drizzleSilk } from "@gqloom/drizzle"
+import * as t from "drizzle-orm/sqlite-core"
+
+export const users = drizzleSilk(
+  t.sqliteTable("users", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    name: t.text().notNull(),
+    age: t.int(),
+    email: t.text(),
+    password: t.text(),
+  })
+)
+
+export const posts = drizzleSilk(
+  t.sqliteTable("posts", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    title: t.text().notNull(),
+    content: t.text(),
+    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
+  })
+)
+```
+
+```ts twoslash title="relations.ts" tab="relations.ts"
+// @filename: schema.ts
+import { drizzleSilk } from "@gqloom/drizzle"
+import * as t from "drizzle-orm/sqlite-core"
+
+export const users = drizzleSilk(
+  t.sqliteTable("users", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    name: t.text().notNull(),
+    age: t.int(),
+    email: t.text(),
+    password: t.text(),
+  })
+)
+
+export const posts = drizzleSilk(
+  t.sqliteTable("posts", {
+    id: t.int().primaryKey({ autoIncrement: true }),
+    title: t.text().notNull(),
+    content: t.text(),
+    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
+  })
+)
+// @filename: relations.ts
+// ---cut---
+import { defineRelations } from "drizzle-orm"
+import * as tables from "./schema"
+
+export const relations = defineRelations(tables, (r) => ({
+  users: {
+    posts: r.many.posts({
+      from: r.users.id,
+      to: r.posts.authorId,
+    }),
+  },
+  posts: {
+    author: r.one.users({
+      from: r.posts.authorId,
+      to: r.users.id,
+    }),
+  },
+}))
+```

--- a/website/snippets/drizzle/v2-type-mapping.md
+++ b/website/snippets/drizzle/v2-type-mapping.md
@@ -1,0 +1,17 @@
+```ts twoslash
+import { extractExtendedColumnType } from "drizzle-orm"
+import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
+import { DrizzleWeaver } from "@gqloom/drizzle"
+
+const drizzleWeaverConfig = DrizzleWeaver.config({
+  presetGraphQLType: (column) => {
+    const { constraint } = extractExtendedColumnType(column)
+    if (constraint === "date") {
+      return GraphQLDateTime
+    }
+    if (constraint === "json") {
+      return GraphQLJSON
+    }
+  },
+})
+```

--- a/website/zh/docs/schema/drizzle.md
+++ b/website/zh/docs/schema/drizzle.md
@@ -10,6 +10,8 @@ import { Tabs } from '@/components/tabs'
 - 使用 Drizzle Table 作为[丝线](../silk)使用；
 - 使用解析器工厂从 Drizzle 快速生成 CRUD 操作。
 
+`@gqloom/drizzle` 同时支持 Drizzle Relational Query API v1（`drizzle-orm` 0.x，`@gqloom/drizzle`）和 v2（`drizzle-orm` 1.0，`@gqloom/drizzle@rc`）。可用 **Relational API v1 / v2** 标签切换示例，本页内会保持同步。
+
 ## 安装
 
 <!--@include: ../../snippets/install-drizzle.md-->
@@ -18,172 +20,33 @@ import { Tabs } from '@/components/tabs'
 
 只需要使用 `drizzleSilk` 包裹 Drizzle Table，我们就可以轻松地将它们作为[丝线](../silk)使用。
 
-```ts twoslash title="schema.ts" tab="schema.ts"
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-silk-schema.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-```
+</template>
+<template #Relational_API_v1>
 
-```ts twoslash title="relations.ts" tab="relations.ts"
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<!--@include: @/snippets/drizzle/v1-silk-schema.md-->
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
-
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-// ---cut---
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
-
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-```
+</template>
+</Tabs>
 
 让我们在解析器中使用它们，同时我们使用 `useSelectedColumns()` 函数以得知当前 GraphQL 查询需要选取哪些列：
 
-```ts twoslash title="resolver.ts"
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-silk-resolver.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
+</template>
+<template #Relational_API_v1>
 
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-// ---cut---
-import { field, query, resolver } from "@gqloom/core"
-import { useSelectedColumns } from "@gqloom/drizzle/context"
-import { eq, inArray } from "drizzle-orm"
-import { drizzle } from "drizzle-orm/libsql"
-import * as v from "valibot"
-import { relations } from "./relations"
-import { posts, users } from "./schema"
+<!--@include: @/snippets/drizzle/v1-silk-resolver.md-->
 
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-export const usersResolver = resolver.of(users, {
-  user: query
-    .output(users.$nullable())
-    .input({ id: v.number() })
-    .resolve(({ id }) => {
-      return db
-        .select(useSelectedColumns(users))
-        .from(users)
-        .where(eq(users.id, id))
-        .get()
-    }),
-
-  users: query.output(users.$list()).resolve(() => {
-    return db.select(useSelectedColumns(users)).from(users).all()
-  }),
-
-  posts: field
-    .output(posts.$list())
-    .derivedFrom("id")
-    .load(async (userList) => {
-      const postList = await db
-        .select()
-        .from(posts)
-        .where(
-          inArray(
-            users.id,
-            userList.map((user) => user.id)
-          )
-        )
-      const groups = new Map<number, (typeof posts.$inferSelect)[]>()
-
-      for (const post of postList) {
-        const key = post.authorId
-        if (key == null) continue
-        groups.set(key, [...(groups.get(key) ?? []), post])
-      }
-      return userList.map((user) => groups.get(user.id) ?? [])
-    }),
-})
-```
+</template>
+</Tabs>
 
 如上面的代码所示，我们可以直接在 `resolver` 里使用 `drizzleSilk` 包裹的 Drizzle Table。  
 在这里我们使用了 `users` 作为 `resolver.of` 的父类型，并在 resolver 中定义了 `user`、`users` 两个查询和一个名为 `posts` 的字段。其中：  
@@ -296,78 +159,12 @@ export const usersResolver = resolver.of(users, {
 <Tabs groupId="drizzle-api-version">
 <template #Relational_API_v2>
 
-```ts [schema.ts]
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { drizzle } from "drizzle-orm/libsql"
-import { relations } from "./relations"
-import { users } from "./schema"
-
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-```
+<!--@include: @/snippets/drizzle/v2-factory-intro.md-->
 
 </template>
 <template #Relational_API_v1>
 
-```ts twoslash [schema.ts]
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
-
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
-
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
-
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-// ---cut---
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { drizzle } from "drizzle-orm/libsql"
-import { relations } from "./relations"
-import { users } from "./schema"
-
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-```
+<!--@include: @/snippets/drizzle/v1-factory-intro.md-->
 
 </template>
 </Tabs>
@@ -376,114 +173,18 @@ const usersResolverFactory = drizzleResolverFactory(db, users)
 
 在 Drizzle Table 中，我们可以轻松地创建[关系](https://orm.drizzle.team/docs/relations)，使用解析器工厂的 `relationField` 方法可以为关系创建对应的 GraphQL 字段。
 
-```ts twoslash [resolver.ts]
-// @filename: schema.ts
-import { drizzleSilk } from "@gqloom/drizzle"
-import * as t from "drizzle-orm/sqlite-core"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-export const users = drizzleSilk(
-  t.sqliteTable("users", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    name: t.text().notNull(),
-    age: t.int(),
-    email: t.text(),
-    password: t.text(),
-  })
-)
+<!--@include: @/snippets/drizzle/v2-relation-field.md-->
 
-export const posts = drizzleSilk(
-  t.sqliteTable("posts", {
-    id: t.int().primaryKey({ autoIncrement: true }),
-    title: t.text().notNull(),
-    content: t.text(),
-    authorId: t.int().references(() => users.id, { onDelete: "cascade" }),
-  })
-)
-// @filename: relations.ts
-import { defineRelations } from "drizzle-orm"
-import * as tables from "./schema"
+</template>
+<template #Relational_API_v1>
 
-export const relations = defineRelations(tables, (r) => ({
-  users: {
-    posts: r.many.posts({
-      from: r.users.id,
-      to: r.posts.authorId,
-    }),
-  },
-  posts: {
-    author: r.one.users({
-      from: r.posts.authorId,
-      to: r.users.id,
-    }),
-  },
-}))
-// @filename: resolver.ts
-import { field, EasyDataLoader } from "@gqloom/core"
-import { createMemoization } from "@gqloom/core/context"
-import { posts } from "schema"
-// ---cut---
-import { query, resolver } from "@gqloom/core"
-import { drizzleResolverFactory } from "@gqloom/drizzle"
-import { eq, inArray } from "drizzle-orm"
-import { drizzle } from "drizzle-orm/libsql"
-import * as v from "valibot"
-import { relations } from "./relations"
-import { users } from "./schema"
+<!--@include: @/snippets/drizzle/v1-relation-field.md-->
 
-const db = drizzle({
-  relations,
-  connection: { url: process.env.DB_FILE_NAME! },
-})
-
-const usersResolverFactory = drizzleResolverFactory(db, users)
-
-const usePostsLoader = createMemoization( // [!code --]
-  () => // [!code --]
-    new EasyDataLoader< // [!code --]
-      { id: number }, // [!code --]
-      (typeof posts.$inferSelect)[] // [!code --]
-    >(async (userList) => { // [!code --]
-      const postList = await db // [!code --]
-        .select() // [!code --]
-        .from(posts) // [!code --]
-        .where( // [!code --]
-          inArray( // [!code --]
-            users.id, // [!code --]
-            userList.map((user) => user.id) // [!code --]
-          ) // [!code --]
-        ) // [!code --]
-      const groups = new Map<number, (typeof posts.$inferSelect)[]>() // [!code --]
-      // [!code --]
-      for (const post of postList) { // [!code --]
-        const key = post.authorId // [!code --]
-        if (key == null) continue // [!code --]
-        groups.set(key, [...(groups.get(key) ?? []), post]) // [!code --]
-      } // [!code --]
-      return userList.map((user) => groups.get(user.id) ?? []) // [!code --]
-    }) // [!code --]
-) // [!code --]
- 
-export const usersResolver = resolver.of(users, {
-  user: query
-    .output(users.$nullable())
-    .input({ id: v.number() })
-    .resolve(({ id }) => {
-      return db.select().from(users).where(eq(users.id, id)).get()
-    }),
-
-  users: query.output(users.$list()).resolve(() => {
-    return db.select().from(users).all()
-  }),
-
-  posts_: field.output(posts.$list()) // [!code --]
-    .derivedFrom('id') // [!code --]
-    .resolve((user) => { // [!code --]
-      return usePostsLoader().load(user) // [!code --]
-    }), // [!code --]
-
-  posts: usersResolverFactory.relationField("posts"), // [!code ++]
-})
-```
+</template>
+</Tabs>
 
 ### 查询
 
@@ -492,6 +193,8 @@ Drizzle 解析器工厂预置了一些常用的查询：
 - `selectArrayQuery`: 根据条件查找对应表的多条记录
 - `selectSingleQuery`: 根据条件查找对应表的一条记录
 - `countQuery`: 根据条件统计对应表的记录数量
+
+以下查询和变更工厂的 GQLoom API 在两个 Relational API 版本中相同。表结构和 `db` 的创建方式见上方标签所选版本。
 
 我们可以在解析器内使用来自解析器工厂的查询：
 
@@ -892,23 +595,18 @@ const usersResolver = usersResolverFactory.resolver()
 
 首先我们使用 `DrizzleWeaver.config` 来定义类型映射的配置。这里我们导入来自 [graphql-scalars](https://the-guild.dev/graphql/scalars) 的 `GraphQLDateTime` 和  `GraphQLJSONObject` ，当遇到 `date` 和 `json` 类型时，我们将其映射到对应的 GraphQL 标量。
 
-```ts twoslash
-import { extractExtendedColumnType } from "drizzle-orm"
-import { GraphQLDateTime, GraphQLJSON } from "graphql-scalars"
-import { DrizzleWeaver } from "@gqloom/drizzle"
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
 
-const drizzleWeaverConfig = DrizzleWeaver.config({
-  presetGraphQLType: (column) => {
-    const { constraint } = extractExtendedColumnType(column)
-    if (constraint === "date") {
-      return GraphQLDateTime
-    }
-    if (constraint === "json") {
-      return GraphQLJSON
-    }
-  },
-})
-```
+<!--@include: @/snippets/drizzle/v2-type-mapping.md-->
+
+</template>
+<template #Relational_API_v1>
+
+<!--@include: @/snippets/drizzle/v1-type-mapping.md-->
+
+</template>
+</Tabs>
 
 在编织 GraphQL Schema 时传入配置到 weave 函数中：
 
@@ -920,15 +618,17 @@ export const schema = weave(drizzleWeaverConfig, usersResolver, postsResolver)
 
 ## 默认类型映射
 
-下表列出了 GQLoom 中 Drizzle `dataType` 与 GraphQL 类型之间的默认映射关系：
+下表列出了 GQLoom 中 Drizzle 类型与 GraphQL 类型之间的默认映射关系：
 
-| Drizzle `dataType` | GraphQL 类型     |
-| ------------------ | ---------------- |
-| boolean            | `GraphQLBoolean` |
-| number             | `GraphQLFloat`   |
-| json               | `GraphQLString`  |
-| date               | `GraphQLString`  |
-| bigint             | `GraphQLString`  |
-| string             | `GraphQLString`  |
-| buffer             | `GraphQLList`    |
-| array              | `GraphQLList`    |
+<Tabs groupId="drizzle-api-version">
+<template #Relational_API_v2>
+
+<!--@include: @/snippets/drizzle/v2-default-mapping.md-->
+
+</template>
+<template #Relational_API_v1>
+
+<!--@include: @/snippets/drizzle/v1-default-mapping.md-->
+
+</template>
+</Tabs>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
相对 `drizzle-rqbv2` 把 Drizzle 文档改成真正的双版本，而不是只剩 v2。

## 背景

`drizzle-rqbv2` 相对 `origin/main` 的 website 改动是 **9 个文件，+451 / -269**：

- `docs/schema/drizzle.md` 与 `zh/docs/schema/drizzle.md` 各约 +202/-118（内容几乎整页改成 `defineRelations`）
- 安装 snippet、首页 / dataloader 示例、`website/package.json` 的 drizzle-orm 版本

原先页面虽然有 `Relational API v1 / v2` 标签，但 v1 标签里仍是 v2 API（`defineRelations`），中英文示例也各自复制一份。

## 改动

- 版本相关示例抽到 `website/snippets/drizzle/`，中英文共用同一份代码
- 用同一个 `groupId="drizzle-api-version"` 切换：
  - **v2**：`defineRelations`、`drizzle({ relations })`、`extractExtendedColumnType`（twoslash，匹配当前 `drizzle-orm@1.0.0-rc.4`）
  - **v1**：`relations()`、`drizzle({ schema })`、`column.dataType`（普通代码块，避免在 rc.4 上类型检查失败）
- 解析器工厂的查询 / 变更 API 两边相同，页面里加了说明

## 仍按当前安装版本展示的部分

首页和 dataloader 的 twoslash snippet、以及 `website/package.json` 仍绑定 `drizzle-orm@1.0.0-rc.4`。文档站一次只能安装一个 Drizzle 版本，这些类型检查示例没法同时跑 0.x 和 1.0。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7af92ed6-c2ea-4839-a7d7-17e9dba29935?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7af92ed6-c2ea-4839-a7d7-17e9dba29935&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

