### PR TITLE
docs(website): 用 Silk 作为 drizzleSilk field，并钉到 0.17.0-rc.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,8 +703,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@gqloom/drizzle':
-        specifier: npm:@gqloom/drizzle@0.17.0-rc.0
-        version: 0.17.0-rc.0(@gqloom/core@packages+core)(drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3))(graphql@16.13.1)
+        specifier: npm:@gqloom/drizzle@0.17.0-rc.1
+        version: 0.17.0-rc.1(@gqloom/core@packages+core)(drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3))(graphql@16.13.1)
       '@gqloom/drizzle-rqbv1':
         specifier: npm:@gqloom/drizzle@0.16.0
         version: '@gqloom/drizzle@0.16.0(@gqloom/core@packages+core)(drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3))(graphql@16.13.1)'
@@ -2068,8 +2068,8 @@ packages:
       drizzle-orm: '>= 0.44.0'
       graphql: ^16.13.1
 
-  '@gqloom/drizzle@0.17.0-rc.0':
-    resolution: {integrity: sha512-9mFD7cdjvStRe4niBPG1D7zasnC3VhZ1elRCcWPvrltFgNXUmxcRaDeUSfZ/wOFu1TRGTKQSRyTS3INm1H6B/Q==}
+  '@gqloom/drizzle@0.17.0-rc.1':
+    resolution: {integrity: sha512-RvgSF3+p9znKZOFLdbJPz0fLA9daAn7tzjhL6pJe/h+oMeEPLSNFdWC/oAcS2szeFJJx3eIVbrUnIBLpsIV51w==}
     peerDependencies:
       '@gqloom/core': '>= 0.10.0'
       drizzle-orm: '>= 1.0.0-rc.4'
@@ -7896,7 +7896,7 @@ snapshots:
       drizzle-orm: 1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
       graphql: 16.13.1
 
-  '@gqloom/drizzle@0.17.0-rc.0(@gqloom/core@packages+core)(drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3))(graphql@16.13.1)':
+  '@gqloom/drizzle@0.17.0-rc.1(@gqloom/core@packages+core)(drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3))(graphql@16.13.1)':
     dependencies:
       '@gqloom/core': link:packages/core
       drizzle-orm: 1.0.0-rc.4(@electric-sql/pglite@0.4.3)(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(arktype@2.2.3)(better-sqlite3@12.6.2)(effect@3.22.1)(mysql2@3.23.3(@types/node@25.9.3))(pg@8.23.0)(postgres@3.4.7)(sqlite3@5.1.7)(typebox@1.3.15)(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "@apollo/server": "^5.5.1",
     "@apollo/subgraph": "^2.14.4",
     "@gqloom/core": "workspace:*",
-    "@gqloom/drizzle": "npm:@gqloom/drizzle@0.17.0-rc.0",
+    "@gqloom/drizzle": "npm:@gqloom/drizzle@0.17.0-rc.1",
     "@gqloom/drizzle-rqbv1": "npm:@gqloom/drizzle@0.16.0",
     "@gqloom/effect": "workspace:*",
     "@gqloom/federation": "workspace:*",

--- a/website/snippets/code/drizzle-valibot.ts
+++ b/website/snippets/code/drizzle-valibot.ts
@@ -1,4 +1,3 @@
-import { silk } from "@gqloom/core"
 import { drizzleSilk } from "@gqloom/drizzle"
 import { asEnumType } from "@gqloom/valibot"
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
@@ -33,8 +32,8 @@ export const users = drizzleSilk(
   }),
   {
     fields: () => ({
-      role: { type: silk.getType(Role) },
-      contactInformation: { type: silk.getType(v.nullish(ContactInformation)) },
+      role: Role,
+      contactInformation: v.nullish(ContactInformation),
     }),
   }
 )

--- a/website/snippets/code/drizzle-zod.ts
+++ b/website/snippets/code/drizzle-zod.ts
@@ -1,4 +1,3 @@
-import { silk } from "@gqloom/core"
 import { drizzleSilk } from "@gqloom/drizzle"
 import { asEnumType } from "@gqloom/zod"
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
@@ -29,8 +28,8 @@ export const users = drizzleSilk(
   }),
   {
     fields: () => ({
-      role: { type: silk.getType(Role) },
-      contactInformation: { type: silk.getType(z.nullish(ContactInformation)) },
+      role: Role,
+      contactInformation: z.nullish(ContactInformation),
     }),
   }
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将 `drizzle-rqbv2` 上对 `/website` 的改动单独合入 `main`，让文档站在两个分支上保持一致。

## 改动

1. **文档示例**（Valibot / Zod）：`drizzleSilk` 的 `fields` 不再写 `{ type: silk.getType(...) }`，改为直接传入 Silk / schema：
   - `role: Role`
   - `contactInformation: v.nullish(ContactInformation)` / `z.nullish(ContactInformation)`
2. **依赖**：文档站 `@gqloom/drizzle` 从已发布的 `0.17.0-rc.0` 钉到 `0.17.0-rc.1`（该版本才支持把 Silk 当 field 值）。

`website/` 目录内容与 `drizzle-rqbv2` 完全一致。根目录 `pnpm-lock.yaml` 只更新了这条 npm alias，没有带上 `drizzle-rqbv2` 的 workspace 锁文件。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10ba9581-b66b-410b-b841-3ebfd7e889a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10ba9581-b66b-410b-b841-3ebfd7e889a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

